### PR TITLE
Degrade keys section gracefully instead of failing the whole dashboard

### DIFF
--- a/healthcheck.py
+++ b/healthcheck.py
@@ -816,6 +816,38 @@ def _get_tailnet_keys_status():
     metrics["tailnet_configured"] = tailnet_configured
     return key_status, metrics
 
+def _get_tailnet_keys_status_safe():
+    """Like _get_tailnet_keys_status, but never raises.
+
+    Used by the dashboard so a keys-specific problem (most commonly the
+    configured credential lacking the Keys scope/capability) degrades
+    that section to an "unavailable" state instead of taking down the
+    whole device health dashboard.
+    """
+    try:
+        return _get_tailnet_keys_status()
+    except requests.exceptions.HTTPError as e:
+        logging.warning(f"Tailnet keys unavailable (upstream error): {e}")
+        payload, _ = _upstream_error_payload(e)
+        error_message = payload["error"]
+    except requests.exceptions.Timeout as e:
+        logging.warning(f"Tailnet keys unavailable (timeout): {e}")
+        error_message = "Request to external API timed out"
+    except Exception as e:
+        logging.warning(f"Tailnet keys unavailable: {e}")
+        error_message = "Unexpected error fetching tailnet keys"
+
+    return [], {
+        "total_keys": 0,
+        "counter_key_healthy_true": 0,
+        "counter_key_healthy_false": 0,
+        "global_keys_healthy": True,
+        "has_keys": False,
+        "key_expiry_warning_days": KEY_EXPIRY_WARNING_DAYS,
+        "tailnet_configured": _is_tailnet_configured(),
+        "keys_error": error_message,
+    }
+
 def _compute_health_summary(devices):
     """Compute normalized device health list and aggregate metrics.
 
@@ -998,8 +1030,12 @@ def ui_dashboard():
         devices = fetch_devices()
         health_list, metrics = _compute_health_summary(devices)
         cache_meta = _get_cache_meta("devices")
-        key_list, key_metrics = _get_tailnet_keys_status()
-        keys_cache_meta = _get_cache_meta("tailnet_keys") if key_metrics["tailnet_configured"] else None
+        key_list, key_metrics = _get_tailnet_keys_status_safe()
+        keys_cache_meta = (
+            _get_cache_meta("tailnet_keys")
+            if key_metrics["tailnet_configured"] and not key_metrics.get("keys_error")
+            else None
+        )
         settings = _build_settings_dict()
         # Load time in configured timezone
         try:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -90,8 +90,10 @@
   <section class="cards">
     <div class="card">
       <div class="card-title">Tailnet Keys</div>
-      <div class="card-metric {{ 'ok' if key_metrics.global_keys_healthy else 'bad' }}">
-        {% if not key_metrics.tailnet_configured %}
+      <div class="card-metric {{ '' if (not key_metrics.tailnet_configured or key_metrics.keys_error) else ('ok' if key_metrics.global_keys_healthy else 'bad') }}">
+        {% if key_metrics.keys_error %}
+          Unavailable
+        {% elif not key_metrics.tailnet_configured %}
           Not Configured
         {% else %}
           {{ key_metrics.counter_key_healthy_true }} / {{ key_metrics.total_keys }}
@@ -115,7 +117,9 @@
           </tr>
         </thead>
         <tbody>
-          {% if not key_metrics.tailnet_configured %}
+          {% if key_metrics.keys_error %}
+          <tr><td colspan="6" class="muted">Tailnet keys are unavailable: {{ key_metrics.keys_error }}. Check that your API token/OAuth client has the <code>Keys</code> scope or capability.</td></tr>
+          {% elif not key_metrics.tailnet_configured %}
           <tr><td colspan="6" class="muted">The <code>TAILNET_DOMAIN</code> environment variable is not configured (it is still set to the default <code>example.com</code>). Set it to your tailnet name to enable key monitoring.</td></tr>
           {% elif not key_metrics.has_keys %}
           <tr><td colspan="6" class="muted">No API or auth keys were found for this tailnet.</td></tr>


### PR DESCRIPTION
If the configured credential can read devices but lacks the Keys scope/capability, the dashboard previously raised the upstream 403 out of ui_dashboard entirely, replacing the whole device health page with a generic error screen. Existing deployments that upgrade without also granting Keys access would lose their dashboard outright.

_get_tailnet_keys_status_safe() now catches HTTPError/Timeout/generic exceptions from the keys fetch and returns an "unavailable" state with the underlying message instead of raising, so the dashboard still renders normally with just that one section marked unavailable. The direct /keys API endpoint is unchanged and still surfaces the real upstream status/error for callers who explicitly want it.