### PR TITLE
Resolve the /data uid automatically so SQLite works on any mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,12 +77,11 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # it detects that and just execs directly, skipping the chown/gosu steps it
 # wouldn't have permission for anyway (see docker-entrypoint.sh).
 #
-# PUID/PGID default to appuser:app (10001:999) - i.e. unchanged behavior -
-# and exist for bind mounts on CIFS/SMB or NFS, where ownership is fixed by
-# the mount options and chown can never succeed. There, set them to the
-# uid/gid the share is mounted as instead of trying to chown it.
-ENV PUID=10001
-ENV PGID=999
+# PUID/PGID are deliberately NOT declared as ENV here. The entrypoint defaults
+# them to appuser:app (10001:999) internally, so their *presence* in the
+# environment is what marks them as an operator override - baking defaults in
+# would make an explicit `-e PUID=10001` indistinguishable from unset, and it
+# would then be silently overridden by the CIFS/NFS owner-adoption fallback.
 ENTRYPOINT ["docker-entrypoint.sh"]
 # --preload imports the app once in the master and forks workers from it, so
 # the interpreter, imports, and module-level setup are shared copy-on-write

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,18 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python3 /app/docker-healthcheck.py || exit 1
 
 # Starts as root by default so the entrypoint can fix /data ownership for
-# arbitrary bind mounts, then drops to appuser via gosu before exec'ing
+# arbitrary bind mounts, then drops to PUID:PGID via gosu before exec'ing
 # gunicorn - but the entrypoint also works correctly if a hardened runtime
 # (e.g. Kubernetes runAsUser/runAsNonRoot) already starts it as non-root:
 # it detects that and just execs directly, skipping the chown/gosu steps it
 # wouldn't have permission for anyway (see docker-entrypoint.sh).
+#
+# PUID/PGID default to appuser:app (10001:999) - i.e. unchanged behavior -
+# and exist for bind mounts on CIFS/SMB or NFS, where ownership is fixed by
+# the mount options and chown can never succeed. There, set them to the
+# uid/gid the share is mounted as instead of trying to chown it.
+ENV PUID=10001
+ENV PGID=999
 ENTRYPOINT ["docker-entrypoint.sh"]
 # --preload imports the app once in the master and forks workers from it, so
 # the interpreter, imports, and module-level setup are shared copy-on-write

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [Generating the Tailscale API Key](#generating-the-tailscale-api-key)
   - [Filter Configuration Examples](#filter-configuration-examples)
 - [🐳 Running with Docker](#-running-with-docker)
+  - [Upgrading](#upgrading-recreate-the-container-dont-just-restart-it)
   - [Storage & permissions](#storage--permissions)
   - [Run with Docker Compose](#run-with-docker-compose)
   - [Build and Run Locally](#build-and-run-locally)
@@ -512,6 +513,40 @@ EXCLUDE_TAG_UPDATE_HEALTHY="test*,dev*"
 ## 🐳 Running with Docker
 
 Note: The container runs as a non-root user (`appuser`, UID 10001) following least-privilege best practices. It binds to the non-privileged port `5000`. If you need to expose a different external port, use Docker's port mapping (e.g., `-p 8080:5000`).
+
+### Upgrading: recreate the container, don't just restart it
+
+Pulling a new image is not enough — **recreate the container** so it picks up the image's current
+`ENTRYPOINT`, `CMD`, `USER` and healthcheck:
+
+```bash
+docker compose pull && docker compose up -d      # compose recreates automatically
+# or, for plain docker run:
+docker pull laitco/tailscale-healthcheck:latest
+docker rm -f tailscale-healthcheck
+docker run -d --name tailscale-healthcheck ...   # same flags as before
+```
+
+Your data lives in the `/data` volume, not the container, so recreating it loses nothing.
+
+> **If you manage containers through a UI** (Portainer, Komodo, Dockge, …), check that it hasn't
+> carried an **Entrypoint**, **Command** or **User** override forward from the previous container.
+> Several of them copy the whole old configuration onto the new image when you redeploy, which
+> pins settings that were only ever meant to be the image's own defaults.
+>
+> Symptom: the container crash-loops with
+> `sqlite3.OperationalError: unable to open database file`, raised from inside
+> `gunicorn_config.py`.
+>
+> Why: a `User` override starts the container as a non-root user, so the entrypoint can neither take
+> ownership of `/data` nor drop privileges — and an `Entrypoint` override bypasses
+> `docker-entrypoint.sh` entirely, so you get the raw SQLite error instead of a message explaining
+> the problem. Clearing an `Entrypoint` override *alone* is not enough either: the container will
+> then start and run **as root**, silently giving up its privilege dropping.
+>
+> Fix: leave **Entrypoint, Command and User empty** so the image supplies them. Recreating the
+> container from scratch and re-adding only your own settings (tailnet domain, credentials,
+> timezone, port, volume) is the most reliable way to clear a stale definition.
 
 ### Storage & permissions
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [Generating the Tailscale API Key](#generating-the-tailscale-api-key)
   - [Filter Configuration Examples](#filter-configuration-examples)
 - [🐳 Running with Docker](#-running-with-docker)
+  - [Storage & permissions](#storage--permissions)
   - [Run with Docker Compose](#run-with-docker-compose)
   - [Build and Run Locally](#build-and-run-locally)
   - [Run from Docker Hub](#run-from-docker-hub)
@@ -511,6 +512,36 @@ EXCLUDE_TAG_UPDATE_HEALTHY="test*,dev*"
 ## 🐳 Running with Docker
 
 Note: The container runs as a non-root user (`appuser`, UID 10001) following least-privilege best practices. It binds to the non-privileged port `5000`. If you need to expose a different external port, use Docker's port mapping (e.g., `-p 8080:5000`).
+
+### Storage & permissions
+
+The app keeps everything (settings, users, device/key snapshots, audit log) in a SQLite database
+under `/data`, so that directory has to be writable by the container. This is handled automatically
+— **you should not normally need to configure anything**:
+
+| How you mount `/data` | What happens |
+|---|---|
+| Docker **named volume** (recommended) | Docker seeds it from the image; works as-is. |
+| **Bind mount** on a normal Linux filesystem | The container starts as root, takes ownership, then drops to the unprivileged `appuser` (uid `10001`). |
+| **Bind mount** on **CIFS/SMB or NFS** (typical NAS setup) | `chown` is refused there — ownership comes from the mount options — so the container instead runs *as the uid the share is mounted as*, and logs a `NOTE` saying so. |
+| Hardened runtime (Kubernetes `runAsUser`, `docker run --user`) | Runs as the uid you specified, unchanged. |
+
+If none of those can write, the container **fails immediately with an explanation** instead of
+crash-looping on an opaque `sqlite3.OperationalError: unable to open database file`.
+
+**`PUID` / `PGID`** (default `10001` / `999`) override the whole thing when you want a specific uid —
+for example to make the database files owned by your own user on a NAS:
+
+```bash
+docker run -e PUID=1000 -e PGID=1000 -v /volume1/docker/tailscale-healthcheck:/data ...
+```
+
+Set explicitly, they are honoured exactly: the container will fail with a clear error rather than
+quietly running as some other user.
+
+> The image's own user is uid `10001` rather than the more familiar `1000` deliberately — it's a
+> reserved system-range id, so it can't collide with a real account on the host. You do not need to
+> match it; the table above means the container adapts to your storage, not the other way round.
 
 ### Run with Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -527,7 +527,26 @@ docker rm -f tailscale-healthcheck
 docker run -d --name tailscale-healthcheck ...   # same flags as before
 ```
 
-Your data lives in the `/data` volume, not the container, so recreating it loses nothing.
+Your data lives in the `/data` volume, not the container — so recreating it loses nothing **as long as
+that volume is a named volume or a bind mount** (`-v tailscale-healthcheck-data:/data` or
+`-v /host/path:/data`), which is how both the Compose file and the documented `docker run` commands
+set it up.
+
+> ⚠️ **If you started the container with no `-v` at all**, the image's `VOLUME ["/data"]` gave it an
+> *anonymous* volume. `docker rm` + `docker run` attaches a **brand-new** anonymous volume, and your
+> settings, users and history are left behind in the old one. Check before removing the container:
+>
+> ```bash
+> docker inspect tailscale-healthcheck --format '{{range .Mounts}}{{.Type}} {{.Name}}{{.Source}} -> {{.Destination}}{{end}}'
+> ```
+>
+> An empty `Name`/`Source` with type `volume` and a long hex id means it's anonymous. Either reattach
+> it explicitly (`-v <that-volume-id>:/data`) or, better, migrate to a named volume first:
+>
+> ```bash
+> docker run --rm -v <old-anonymous-volume-id>:/from -v tailscale-healthcheck-data:/to \
+>   alpine sh -c 'cp -a /from/. /to/'
+> ```
 
 > **If you manage containers through a UI** (Portainer, Komodo, Dockge, …), check that it hasn't
 > carried an **Entrypoint**, **Command** or **User** override forward from the previous container.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,21 +1,131 @@
 #!/bin/sh
-# When started as root (the plain `docker run` default for this image, since
-# no USER is declared), fixes ownership of a bind-mounted /data volume (which
-# may come from the host owned by an arbitrary user/root) then drops
-# privileges to the unprivileged appuser before executing the real command.
+# Makes the SQLite data directory writable and drops privileges, working across
+# every deployment shape without the operator having to configure anything.
 #
-# When a hardened runtime already starts the container as non-root (e.g.
-# Kubernetes runAsUser/runAsNonRoot), skips both steps entirely instead of
-# failing: it has no permission to chown someone else's files anyway, and
-# gosu itself requires root to change user, so calling it while already
-# non-root would just crash the container instead of running it.
+# The app opens a SQLite database under /data, so that directory must be
+# writable by whatever uid the app ends up running as. Getting there differs by
+# how /data was provided:
+#
+#   * Docker named volume      - Docker seeds it from the image, already ours.
+#   * Bind mount, Linux fs     - chown it (we start as root by default).
+#   * Bind mount, CIFS/SMB/NFS - chown is refused or a silent no-op, because
+#                                ownership comes from the mount options. The
+#                                only way to write there is to *be* the uid the
+#                                share is mounted as.
+#   * Hardened runtime         - Kubernetes runAsUser/runAsNonRoot already
+#                                picked a uid and we can't chown or gosu at all.
+#
+# So rather than demanding a specific uid, this resolves the first uid that can
+# actually write, in order of preference, and only fails when no uid can (a
+# genuinely read-only mount, which no configuration can fix).
+#
+# PUID/PGID override the whole thing. Setting them explicitly is a deliberate
+# choice, so it's honoured exactly and fails loudly rather than being silently
+# second-guessed.
 set -e
 
-if [ "$(id -u)" = "0" ]; then
-    if [ -d /data ]; then
-        chown -R appuser:app /data || true
+DEFAULT_UID=10001   # appuser, created in the Dockerfile
+DEFAULT_GID=999     # app
+
+# The image sets PUID/PGID as ENV defaults, so "did the operator choose this?"
+# can't be answered by emptiness alone - compare against the known defaults.
+PUID_EXPLICIT=""
+[ "${PUID:-$DEFAULT_UID}" = "$DEFAULT_UID" ] || PUID_EXPLICIT=1
+[ "${PGID:-$DEFAULT_GID}" = "$DEFAULT_GID" ] || PUID_EXPLICIT=1
+PUID="${PUID:-$DEFAULT_UID}"
+PGID="${PGID:-$DEFAULT_GID}"
+
+# Probe the directory the app will really use, not a hardcoded /data, so this
+# stays honest when DATABASE_PATH points elsewhere.
+DB_PATH="${DATABASE_PATH:-/data/healthcheck.db}"
+DB_DIR="$(dirname "$DB_PATH")"
+
+# True if uid:gid can create a file in DB_DIR. An actual write, not a mode
+# inspection - only a real touch accounts for NFS squashing, read-only mounts,
+# ACLs and friends.
+can_write_as() {
+    _probe="$DB_DIR/.write-probe.$$"
+    if [ "$(id -u)" = "0" ]; then
+        gosu "$1:$2" sh -c "touch '$_probe' 2>/dev/null && rm -f '$_probe' && echo yes" 2>/dev/null || true
+    else
+        sh -c "touch '$_probe' 2>/dev/null && rm -f '$_probe' && echo yes" 2>/dev/null || true
     fi
-    exec gosu appuser "$@"
-else
+}
+
+fail_unwritable() {
+    _uid="$1"
+    _owner=$(stat -c '%u:%g' "$DB_DIR" 2>/dev/null || echo 'unknown')
+    _mode=$(stat -c '%a' "$DB_DIR" 2>/dev/null || echo 'unknown')
+    echo "FATAL: $DB_DIR is not writable by uid $_uid, and no usable uid could be found." >&2
+    echo "       It is owned by $_owner with mode $_mode." >&2
+    echo "       This usually means the volume is mounted read-only." >&2
+    echo "" >&2
+    echo "  Fix one of these, then restart the container:" >&2
+    echo "    * Remove any :ro flag from the volume mount." >&2
+    echo "    * Bind mount on a normal Linux filesystem:" >&2
+    echo "        chown -R $DEFAULT_UID:$DEFAULT_GID <host path>" >&2
+    echo "    * Bind mount on CIFS/SMB or NFS:" >&2
+    echo "        set PUID/PGID to the uid/gid the share is mounted as," >&2
+    echo "        e.g. -e PUID=1000 -e PGID=1000" >&2
+    echo "    * Simplest: use a Docker named volume instead of a bind mount," >&2
+    echo "        e.g. -v tailscale-healthcheck-data:/data" >&2
+    exit 1
+}
+
+if [ ! -d "$DB_DIR" ]; then
+    # Only reachable when DATABASE_PATH points somewhere unmounted; /data
+    # itself is created in the image.
+    if [ "$(id -u)" = "0" ]; then
+        mkdir -p "$DB_DIR" 2>/dev/null || true
+    fi
+    if [ ! -d "$DB_DIR" ]; then
+        echo "FATAL: database directory $DB_DIR does not exist and could not be created." >&2
+        echo "       Mount a volume there, or point DATABASE_PATH at an existing path." >&2
+        exit 1
+    fi
+fi
+
+# Already non-root (Kubernetes runAsUser, docker run --user, rootless): we
+# can neither chown nor switch user, so this uid is the only candidate.
+if [ "$(id -u)" != "0" ]; then
+    [ "$(can_write_as "$(id -u)" "$(id -g)")" = "yes" ] || fail_unwritable "$(id -u)"
     exec "$@"
 fi
+
+# Best effort; expected to fail on CIFS/NFS, which is not fatal on its own.
+chown -R "$PUID:$PGID" "$DB_DIR" 2>/dev/null || true
+
+if [ -n "$PUID_EXPLICIT" ]; then
+    # Explicitly configured: honour it exactly, or fail - never silently run as
+    # a different user than the operator asked for.
+    [ "$(can_write_as "$PUID" "$PGID")" = "yes" ] || fail_unwritable "$PUID"
+    exec gosu "$PUID:$PGID" "$@"
+fi
+
+# Defaults in play: find the first uid that can actually write.
+if [ "$(can_write_as "$PUID" "$PGID")" = "yes" ]; then
+    exec gosu "$PUID:$PGID" "$@"
+fi
+
+# The chown didn't take (CIFS/SMB/NFS). Adopt whoever does own the directory -
+# on those mounts that's precisely the uid the share was mounted as.
+OWNER_UID=$(stat -c '%u' "$DB_DIR" 2>/dev/null || echo '')
+OWNER_GID=$(stat -c '%g' "$DB_DIR" 2>/dev/null || echo '')
+if [ -n "$OWNER_UID" ] && [ "$OWNER_UID" != "0" ] && [ "$(can_write_as "$OWNER_UID" "$OWNER_GID")" = "yes" ]; then
+    echo "NOTE: could not take ownership of $DB_DIR (expected on CIFS/SMB and NFS mounts)." >&2
+    echo "      Running as its existing owner $OWNER_UID:$OWNER_GID instead." >&2
+    echo "      Set PUID/PGID explicitly to override this." >&2
+    exec gosu "$OWNER_UID:$OWNER_GID" "$@"
+fi
+
+# Last resort: the directory is root-owned and closed to everyone else, and we
+# couldn't chown it. Staying root is worse for isolation but is the difference
+# between running and a crash loop, so warn loudly rather than refuse.
+if [ "$(can_write_as 0 0)" = "yes" ]; then
+    echo "WARNING: $DB_DIR is writable only by root and its ownership could not be changed." >&2
+    echo "         Continuing as root - this gives up the container's privilege dropping." >&2
+    echo "         To fix: chown -R $DEFAULT_UID:$DEFAULT_GID <host path>, or set PUID/PGID." >&2
+    exec "$@"
+fi
+
+fail_unwritable "$PUID"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,11 +27,13 @@ set -e
 DEFAULT_UID=10001   # appuser, created in the Dockerfile
 DEFAULT_GID=999     # app
 
-# The image sets PUID/PGID as ENV defaults, so "did the operator choose this?"
-# can't be answered by emptiness alone - compare against the known defaults.
-PUID_EXPLICIT=""
-[ "${PUID:-$DEFAULT_UID}" = "$DEFAULT_UID" ] || PUID_EXPLICIT=1
-[ "${PGID:-$DEFAULT_GID}" = "$DEFAULT_GID" ] || PUID_EXPLICIT=1
+# Presence, not value, marks an operator override - the Dockerfile deliberately
+# does not declare PUID/PGID as ENV for exactly this reason. Comparing against
+# the defaults instead would make an explicit `-e PUID=10001` look unset, and
+# the owner-adoption fallback below would then silently ignore it.
+ID_OVERRIDE_SET=""
+[ -z "${PUID+set}" ] || ID_OVERRIDE_SET=1
+[ -z "${PGID+set}" ] || ID_OVERRIDE_SET=1
 PUID="${PUID:-$DEFAULT_UID}"
 PGID="${PGID:-$DEFAULT_GID}"
 
@@ -40,16 +42,56 @@ PGID="${PGID:-$DEFAULT_GID}"
 DB_PATH="${DATABASE_PATH:-/data/healthcheck.db}"
 DB_DIR="$(dirname "$DB_PATH")"
 
+# DATABASE_PATH is operator-supplied, and dirname of a bare "/healthcheck.db"
+# is "/". Taking ownership of the resolved directory must never be able to
+# sweep the filesystem root or a system directory, so refuse outright rather
+# than trying to make such a path work.
+case "$DB_DIR" in
+    /|/bin|/boot|/dev|/etc|/home|/lib|/lib32|/lib64|/libx32|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/usr|/var|/app)
+        echo "FATAL: DATABASE_PATH=$DB_PATH puts the database directly in $DB_DIR." >&2
+        echo "       Refusing to manage ownership of a system directory." >&2
+        echo "       Point DATABASE_PATH at a dedicated directory, e.g." >&2
+        echo "       DATABASE_PATH=/data/healthcheck.db" >&2
+        exit 1
+        ;;
+    /*) ;;
+    *)
+        echo "FATAL: DATABASE_PATH=$DB_PATH must be an absolute path." >&2
+        exit 1
+        ;;
+esac
+
 # True if uid:gid can create a file in DB_DIR. An actual write, not a mode
 # inspection - only a real touch accounts for NFS squashing, read-only mounts,
 # ACLs and friends.
+#
+# Root only: switching user requires gosu, which requires root. The non-root
+# case has its own can_write_now() rather than silently ignoring the arguments.
 can_write_as() {
-    _probe="$DB_DIR/.write-probe.$$"
-    if [ "$(id -u)" = "0" ]; then
-        gosu "$1:$2" sh -c "touch '$_probe' 2>/dev/null && rm -f '$_probe' && echo yes" 2>/dev/null || true
-    else
-        sh -c "touch '$_probe' 2>/dev/null && rm -f '$_probe' && echo yes" 2>/dev/null || true
-    fi
+    # The probe path is passed as a positional argument rather than spliced
+    # into the shell program: DATABASE_PATH is operator-supplied, so a quote in
+    # it would otherwise break the quoting (rejecting a perfectly writable
+    # directory) and a crafted value could inject commands into the inner sh.
+    gosu "$1:$2" sh -c 'touch "$1" 2>/dev/null && rm -f "$1" && echo yes' sh "$DB_DIR/.write-probe.$$" 2>/dev/null || true
+}
+
+# Same probe as the current user, for when we're already non-root and cannot
+# switch to any other uid to test on its behalf.
+can_write_now() {
+    sh -c 'touch "$1" 2>/dev/null && rm -f "$1" && echo yes' sh "$DB_DIR/.write-probe.$$" 2>/dev/null || true
+}
+
+# Take ownership of the database directory and the app's own files only.
+# A recursive chown would rewrite ownership of anything else sharing the
+# directory, which matters as soon as DATABASE_PATH points somewhere the app
+# doesn't exclusively own. These are the only paths the app ever writes.
+take_ownership() {
+    chown "$1:$2" "$DB_DIR" 2>/dev/null || true
+    for _f in "$DB_PATH" "$DB_PATH-wal" "$DB_PATH-shm" "$DB_DIR/poller.lock"; do
+        if [ -e "$_f" ]; then
+            chown "$1:$2" "$_f" 2>/dev/null || true
+        fi
+    done
 }
 
 fail_unwritable() {
@@ -108,14 +150,14 @@ fi
 # Already non-root (Kubernetes runAsUser, docker run --user, rootless): we
 # can neither chown nor switch user, so this uid is the only candidate.
 if [ "$(id -u)" != "0" ]; then
-    [ "$(can_write_as "$(id -u)" "$(id -g)")" = "yes" ] || fail_unwritable "$(id -u)"
+    [ "$(can_write_now)" = "yes" ] || fail_unwritable "$(id -u)"
     exec "$@"
 fi
 
 # Best effort; expected to fail on CIFS/NFS, which is not fatal on its own.
-chown -R "$PUID:$PGID" "$DB_DIR" 2>/dev/null || true
+take_ownership "$PUID" "$PGID"
 
-if [ -n "$PUID_EXPLICIT" ]; then
+if [ -n "$ID_OVERRIDE_SET" ]; then
     # Explicitly configured: honour it exactly, or fail - never silently run as
     # a different user than the operator asked for.
     [ "$(can_write_as "$PUID" "$PGID")" = "yes" ] || fail_unwritable "$PUID"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,19 +56,39 @@ fail_unwritable() {
     _uid="$1"
     _owner=$(stat -c '%u:%g' "$DB_DIR" 2>/dev/null || echo 'unknown')
     _mode=$(stat -c '%a' "$DB_DIR" 2>/dev/null || echo 'unknown')
-    echo "FATAL: $DB_DIR is not writable by uid $_uid, and no usable uid could be found." >&2
+    echo "FATAL: $DB_DIR is not writable by uid $_uid." >&2
     echo "       It is owned by $_owner with mode $_mode." >&2
-    echo "       This usually means the volume is mounted read-only." >&2
     echo "" >&2
-    echo "  Fix one of these, then restart the container:" >&2
-    echo "    * Remove any :ro flag from the volume mount." >&2
-    echo "    * Bind mount on a normal Linux filesystem:" >&2
-    echo "        chown -R $DEFAULT_UID:$DEFAULT_GID <host path>" >&2
-    echo "    * Bind mount on CIFS/SMB or NFS:" >&2
-    echo "        set PUID/PGID to the uid/gid the share is mounted as," >&2
-    echo "        e.g. -e PUID=1000 -e PGID=1000" >&2
-    echo "    * Simplest: use a Docker named volume instead of a bind mount," >&2
-    echo "        e.g. -v tailscale-healthcheck-data:/data" >&2
+
+    if [ "$(id -u)" != "0" ]; then
+        # Started non-root (docker run --user, compose `user:`, Portainer's
+        # User field, Kubernetes runAsUser). We can neither chown nor switch
+        # user from here, so PUID/PGID and named volumes are NOT the fix and
+        # suggesting them just sends people in circles - this is host-side.
+        echo "  This container was started as a non-root user, so it cannot take" >&2
+        echo "  ownership of the directory itself. Fix one of these on the host:" >&2
+        echo "" >&2
+        echo "    * Make the directory match the uid you are running as:" >&2
+        echo "        chown -R $_uid:$(id -g) <host path>" >&2
+        echo "    * Or drop the user override (remove \`user:\` from compose /" >&2
+        echo "      clear the User field / omit --user) and let the container" >&2
+        echo "      fix ownership itself on startup." >&2
+        echo "    * Note: PUID/PGID have no effect here - they only apply when" >&2
+        echo "      the container starts as root." >&2
+    else
+        echo "  The directory could not be chowned and no usable uid was found;" >&2
+        echo "  this usually means the volume is mounted read-only." >&2
+        echo "" >&2
+        echo "  Fix one of these, then restart the container:" >&2
+        echo "    * Remove any :ro flag from the volume mount." >&2
+        echo "    * Bind mount on a normal Linux filesystem:" >&2
+        echo "        chown -R $DEFAULT_UID:$DEFAULT_GID <host path>" >&2
+        echo "    * Bind mount on CIFS/SMB or NFS:" >&2
+        echo "        set PUID/PGID to the uid/gid the share is mounted as," >&2
+        echo "        e.g. -e PUID=1000 -e PGID=1000" >&2
+        echo "    * Simplest: use a Docker named volume instead of a bind mount," >&2
+        echo "        e.g. -v tailscale-healthcheck-data:/data" >&2
+    fi
     exit 1
 }
 

--- a/docker-healthcheck.py
+++ b/docker-healthcheck.py
@@ -6,6 +6,16 @@ through /admin/settings (a DB-only secret, not an env var) - this reads the
 effective value (env-first, DB-fallback, same resolution as the app itself)
 directly from SQLite before making the request, so the probe still works
 regardless of where the token was configured.
+
+The probe measures liveness - "is the app serving?" - and must not report a
+healthy container as unhealthy just because *it* couldn't read the token.
+Docker runs HEALTHCHECK as the image's user (root, since no USER is declared),
+not as the uid the entrypoint resolved for the data directory, so the database
+can legitimately be unreadable here while the app itself is running fine: on an
+NFS export with root_squash, root maps to the anonymous uid and cannot open a
+database owned by the share's uid. Both that read failure and the resulting
+401 are therefore treated as "app is up", since a 401 is itself proof the HTTP
+server responded.
 """
 import os
 import sys
@@ -14,7 +24,16 @@ import urllib.request
 import dbstore
 
 port = os.environ.get("PORT", "5000")
-token = dbstore.get_setting("health_endpoint_token")
+
+try:
+    token = dbstore.get_setting("health_endpoint_token")
+    token_known = True
+except Exception:
+    # Unreadable database (root_squash, permissions, mid-migration lock...).
+    # Fall back to an unauthenticated probe rather than failing outright.
+    token = None
+    token_known = False
+
 headers = {"X-Health-Token": token} if token else {}
 
 try:
@@ -22,5 +41,10 @@ try:
         urllib.request.Request(f"http://localhost:{port}/health", headers=headers), timeout=5
     ) as resp:
         sys.exit(0 if resp.status == 200 else 1)
+except urllib.error.HTTPError as e:
+    # 401 with a token we couldn't look up means the app is serving and simply
+    # rejected an under-credentialed probe - healthy. A 401 when we *did* read
+    # the token is a real mismatch worth surfacing.
+    sys.exit(0 if (e.code == 401 and not token_known) else 1)
 except Exception:
     sys.exit(1)


### PR DESCRIPTION
## ⚠️ Breaking Changes

**Recreate the container when upgrading — pulling the image and restarting is not enough.**

This release changes the container's entrypoint, which is what fixes the startup crash below. An existing container keeps the `Entrypoint`, `Command` and `User` it was created with, so a pull-and-restart runs the new code under the old startup behaviour and the fix won't apply.

```bash
docker compose pull && docker compose up -d      # compose recreates for you
# or:
docker pull laitco/tailscale-healthcheck:latest
docker rm -f tailscale-healthcheck && docker run -d --name tailscale-healthcheck ...
```

**Symptom this fixes** — the container crash-loops on start with:

```
sqlite3.OperationalError: unable to open database file
```

If you manage containers through a UI (Portainer, Komodo, Dockge, …), check that it hasn't carried an **Entrypoint**, **Command** or **User** override forward from the old container. Several of them copy the whole previous configuration onto the new image, which pins values that were only ever meant to be the image's own defaults.

## The bug

The container starts as root, chowns `/data` to `appuser` (uid 10001), then drops to it. When that chown can't take effect, uid 10001 has no write access and the app dies with:

```
File "/app/gunicorn_config.py", line 3, in <module>
  from healthcheck import initialize_oauth
...
sqlite3.OperationalError: unable to open database file
```

Two things made this hard to act on:

- The failure surfaces from inside gunicorn's *config loader* (`gunicorn_config.py` imports `healthcheck`, which calls `dbstore.init_db()` at import), so the traceback points at OAuth wiring rather than at a permissions problem.
- `chown ... || true` swallowed the real cause entirely.

This is long-standing, not a 1.4.0 regression — the same code path exists in 1.3.x.

## The fix

The entrypoint no longer demands a particular uid. It resolves the first uid that can **actually** write, confirmed with a real `touch` (a mode check would lie about NFS squashing, ACLs and read-only mounts):

1. **`PUID`/`PGID` if set explicitly** — honoured exactly, or fail. A configured uid is a deliberate choice and is never silently second-guessed.
2. **`appuser` (10001:999) after chowning** — named volumes and ordinary bind mounts. Unchanged behaviour for existing deployments.
3. **The directory's existing owner**, when the chown didn't take. On CIFS/NFS that is precisely the uid the share is mounted as, so these now work with no configuration at all.
4. **root**, if the directory is root-only and un-chownable — warns loudly, but running beats a crash loop.
5. Otherwise **fail with an actionable message** naming the owner, the mode and the specific fixes, rather than an opaque SQLite error.

The message is context-aware: a container started non-root (`--user`, compose `user:`, Kubernetes `runAsUser`) can neither chown nor switch user, so it is told to fix host ownership or drop the override, and told plainly that `PUID`/`PGID` do nothing in that case.

### New environment variables

| Variable | Default | Description |
|---|---|---|
| `PUID` | `10001` | uid the app runs as. Only needed to override the automatic resolution above. |
| `PGID` | `999` | gid the app runs as. |

Defaults reproduce today's behaviour exactly. The image keeps uid `10001` rather than the more familiar `1000` deliberately: it's a reserved system-range id that can't collide with a real host account, and step 3 means NAS users never need to know the number.

## Verified

Every path exercised in real containers, with CIFS simulated via `--cap-drop=CHOWN` (which makes `chown` fail exactly as SMB does):

| scenario | runs as | exit |
|---|---|---|
| named volume | 10001:999 | 0 |
| bind mount, root-owned, normal fs | 10001:999 | 0 |
| bind mount, uid 1000, chown blocked (CIFS) | 1000:1000 | 0 |
| bind mount, root-only `700`, chown blocked | 0:0 + warning | 0 |
| explicit `PUID=1000` | 1000:1000 | 0 |
| `--user 1000:1000` (Kubernetes style) | 1000:1000 | 0 |
| read-only mount | — | **1**, clear message |

The CIFS case boots healthy, creates the database on the share as uid 1000 and serves `/health` 200.

## Docs

Also documents a second, separate trap found while debugging this: **pulling a new image does not update an existing container**. UI-managed deployments (Portainer, Komodo, Dockge) copy the previous container's `Entrypoint`, `Command` and `User` onto the new image, pinning values meant to be image defaults. That produces the identical SQLite crash — a `User` override starts the container non-root so the entrypoint can't chown or drop privileges, and an `Entrypoint` override bypasses `docker-entrypoint.sh` so the explanatory message never prints. Clearing only the `Entrypoint` override isn't sufficient either: the container then starts, but as root.

README gains an **Upgrading** section (recreate, don't restart) and a **Storage & permissions** section covering all four mount shapes.

## Notes

- No application code changed; 191 backend tests still pass, flake8/oxlint/tsc clean.
- No migration and no action required for working deployments.
- Users currently broken on 1.4.0 can unblock without upgrading via `chown -R 10001:999 <host path>` or by switching to a named volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve container startup user and storage permissions so the SQLite data directory is writable across diverse mount and runtime configurations.

Bug Fixes:
- Prevent SQLite database startup failures when /data is on bind mounts, NAS-style CIFS/SMB or NFS volumes, or otherwise has incompatible ownership/permissions.
- Fail fast with clear, actionable messages when the database directory is missing or genuinely unwritable instead of crash-looping with a generic sqlite3 error.

Enhancements:
- Add logic in the Docker entrypoint to automatically detect a writable uid/gid for the database directory, including honoring explicit PUID/PGID, handling non-root runtimes, and gracefully falling back when chown is ineffective.
- Allow the entrypoint to adapt to DATABASE_PATH so it validates and prepares the actual database directory rather than assuming a hardcoded /data path.
- Improve privilege-dropping behavior by choosing the most appropriate user for the mounted storage, with a last-resort root fallback that logs a clear warning.

Build:
- Expose PUID and PGID as Docker image environment variables, defaulting to the existing appuser uid/gid while allowing explicit override for bind-mounted storage on CIFS/SMB or NFS.

Documentation:
- Document upgrade best practices emphasizing container recreation so image-provided ENTRYPOINT, CMD, USER and healthcheck are applied correctly.
- Add storage and permissions documentation describing how the image behaves with different volume types and how to use PUID/PGID to match NAS-mounted shares.

