### PR TITLE
Add DynDNS public-IP posture synchronization

### DIFF
--- a/.github/workflows/validate-pr_commits.yml
+++ b/.github/workflows/validate-pr_commits.yml
@@ -39,7 +39,7 @@ jobs:
           pip install flake8 pytest
 
       - name: Lint
-        run: flake8 healthcheck.py dbstore.py auth.py poller.py admin.py notifier.py gunicorn_config.py
+        run: flake8 healthcheck.py dbstore.py auth.py poller.py public_ip_updater.py admin.py notifier.py gunicorn_config.py
 
       - name: Test
         env:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [📡 Endpoints](#-endpoints)
   - [`/health`](#health)
   - [`/keys`](#keys)
+  - [`/public-ip`](#public-ip)
   - [`/health/<identifier>`](#healthidentifier)
   - [`/health/healthy`](#healthhealthy)
   - [`/health/unhealthy`](#healthunhealthy)
@@ -36,6 +37,7 @@
   - [Background Polling](#background-polling)
   - [Read-Only Proxy](#read-only-proxy)
 - [🔐 Admin UI](#-admin-ui)
+  - [Public-IP posture synchronization](#public-ip-posture-synchronization)
   - [Response Metrics](#response-metrics)
   - [Using OAuth for Authentication](#using-oauth-for-authentication-recommended)
   - [Creating a Tailscale OAuth Client](#creating-a-tailscale-oauth-client)
@@ -208,6 +210,55 @@ If `TAILNET_DOMAIN` is left at its default (`example.com`), or the tailnet simpl
 ```
 This passthrough applies to `/health`, `/keys`, and their variants (`/health/<identifier>`, `/health/healthy`, `/health/unhealthy`), as well as the dashboard and device detail pages (rendered as an error page with the same status code).
 
+### `/public-ip`
+
+Returns the current status of every configured DynDNS → Tailscale `ip:publicAddress` posture mapping. This is a read-only monitoring endpoint: it never performs DNS resolution or writes the policy during the request. Status comes from the most recent scheduled or manual synchronization.
+
+When `HEALTH_ENDPOINT_TOKEN` is configured, send it in the `X-Health-Token` header, exactly as for `/health`. Disabled mappings remain in `mappings` for visibility, but their `healthy` value is `null` and they are excluded from the enabled health counters.
+
+**Example Response**:
+
+```json
+{
+  "mappings": [
+    {
+      "id": 1,
+      "hostname": "home.example.net",
+      "posture_name": "posture:Home",
+      "enabled": true,
+      "status": "healthy",
+      "healthy": true,
+      "resolved_ip": "8.8.8.8",
+      "configured_ip": "8.8.8.8",
+      "last_checked_at": "2026-08-12T08:30:00+00:00",
+      "last_success_at": "2026-08-12T08:30:00+00:00",
+      "last_changed_at": "2026-08-11T17:42:00+00:00",
+      "last_error": null
+    }
+  ],
+  "metrics": {
+    "updater_enabled": true,
+    "errors_affect_health": true,
+    "global_public_ip_healthy": true,
+    "total_mappings": 1,
+    "enabled_mappings": 1,
+    "counter_mapping_healthy": 1,
+    "counter_mapping_error": 0,
+    "counter_mapping_pending": 0
+  },
+  "poll_meta": {
+    "last_polled_at": "2026-08-12T08:30:00+00:00",
+    "poll_interval_seconds": 60,
+    "timezone": "Europe/Berlin",
+    "last_poll_ok": true,
+    "last_poll_error": null,
+    "last_poll_auth_error": false
+  }
+}
+```
+
+`global_public_ip_healthy` becomes `false` when any enabled mapping has status `error`. Whether that also makes `/health` report `metrics.global_healthy: false` is controlled separately by `PUBLIC_IP_ERRORS_AFFECT_HEALTH`.
+
 ### `/health/<identifier>`
 Returns the health status of a specific device by hostname, ID, name, or machine name (the part of the name before the first dot). Matching is case-insensitive. A device excluded by the device filters (`INCLUDE_OS`/`EXCLUDE_TAGS`/…) is not addressable here and returns `404`, the same as an unknown identifier. Its `metrics` block is scoped to the single returned device.
 
@@ -250,7 +301,7 @@ The application is configured using environment variables:
 | `PUBLIC_IP_UPDATER_ENABLED` | `NO`        | Enable scheduled synchronization of mappings configured on `/admin/public-ip`. |
 | `PUBLIC_IP_BACKUP_RETENTION_DAYS` | `30`  | Retain updater-created HuJSON policy backups for this many days under the database directory. |
 | `PUBLIC_IP_ERRORS_AFFECT_HEALTH` | `NO`   | Make an enabled mapping's latest synchronization error affect `global_healthy`. |
-| `HEALTH_ENDPOINT_TOKEN` | `""` (disabled) | Optional shared secret guarding the public `/health` endpoint. When set, requests must include a matching `X-Health-Token` header or get `401`. Also editable via `/admin/settings`. |
+| `HEALTH_ENDPOINT_TOKEN` | `""` (disabled) | Optional shared secret guarding the public monitoring endpoints, including `/health`, `/keys`, and `/public-ip`. When set, requests must include a matching `X-Health-Token` header or get `401`. Also editable via `/admin/settings`. |
 | `TRUSTED_PROXY_COUNT` | `0`              | Number of reverse proxies in front of the app. `0` trusts nothing and uses the direct peer address; set it to your real proxy count (usually `1`) so per-IP rate limits and the failed-login lockout key off the actual client. Needs a restart. See [Security](#security). |
 | `SESSION_COOKIE_SECURE` | `NO`           | Add the `Secure` flag to the admin session cookie. Set `YES` when serving over HTTPS. Needs a restart. |
 | `SESSION_LIFETIME_MINUTES` | `43200`     | Admin session lifetime in minutes (default 30 days). Needs a restart.       |
@@ -381,7 +432,7 @@ Notes:
 
 - Every route except `/admin/*` enforces read-only access: only `GET`, `HEAD`, and `OPTIONS` are allowed. Modifying methods (`POST`, `PUT`, `PATCH`, `DELETE`) are blocked with `403 Forbidden` and attempts are logged for auditing. This behavior is not user-configurable by design.
 - `/admin/*` is the one exception: it's where the setup wizard, login, settings, user management, and audit log live, and it legitimately needs `POST`/`DELETE`. It's protected by login instead (see [Admin UI](#-admin-ui)).
-- **The entire JSON API family stays public and unauthenticated by default**: `/health`, `/health/` (redirect), `/health/<identifier>`, `/health/healthy`, `/health/unhealthy`, `/health/cache/invalidate`, and `/keys` - that's the contract existing monitoring integrations (Gatus, etc.) depend on. Only the human dashboard (`/`, `/dashboard`, `/devices`, `/tailnet-keys`, `/debug`, `/device/<identifier>`) and `/admin/*` (except the setup/login endpoints themselves) require a logged-in session.
+- **The entire JSON API family stays public and unauthenticated by default**: `/health`, `/health/` (redirect), `/health/<identifier>`, `/health/healthy`, `/health/unhealthy`, `/health/cache/invalidate`, `/keys`, and `/public-ip` - that's the contract existing monitoring integrations (Gatus, etc.) depend on. Only the human dashboard (`/`, `/dashboard`, `/devices`, `/tailnet-keys`, `/debug`, `/device/<identifier>`) and `/admin/*` (except the setup/login endpoints themselves) require a logged-in session.
 - The whole JSON API family can optionally be locked down with `HEALTH_ENDPOINT_TOKEN` (see Configuration) without requiring a login session - useful if you want to keep it out of a login flow (for monitoring tools) but still restrict who can query it. Leave it unset to keep it fully open, as it is by default.
 
 ## 🔐 Admin UI
@@ -396,10 +447,24 @@ Notes:
   - **Changed field** narrows to entries that touched one specific field, e.g. only `os` changes or only `update_available` flips, across both the "old → new" update entries and the created/removed snapshots. Settings are excluded from this select, since a setting's "field" is its name - filter those by entity id instead.
   - **Changes contain** is a substring search over the change data itself, so it matches *values* as well as field names: a hostname, a client version, or the old/new value of a setting. It's case-insensitive, and `%`/`_` are treated literally rather than as wildcards.
   - Every filter (plus the current page) is stored in the query string, so a dug-out view is a shareable link and survives a reload or back/forward navigation. Only meaningful field changes are recorded (not noisy fields like `lastSeen`, and repeat pollings that produce no change never add a duplicate row); entries older than `AUDIT_RETENTION_DAYS` (default 14, editable in `/admin/settings`) are purged automatically as part of each poll cycle.
-- **API docs**: `/admin/api-docs` documents every `/health*`/`/keys` endpoint (description + params on the left, an interactive "Try it" panel on the right) with example responses and a "Try it" button that calls the live API using the configured `API_BASE_URL` (or the current origin); when `HEALTH_ENDPOINT_TOKEN` is set, an `X-Health-Token` input appears for the `/health` "Try it" panel.
-- **Debug page**: `/debug` shows the background poller's recent activity (persisted in the `poller_log` table, not just in-memory - so it survives worker restarts), filterable by event type (`poll_started`, `devices_success`, `devices_error`, `keys_success`, `keys_error`, `poll_completed`, `poll_skipped`); capture is controlled by `DEBUG_LOG_ENABLED`, retention by `POLLER_LOG_RETENTION_DAYS` (default 7).
+- **API docs**: `/admin/api-docs` documents every `/health*`, `/keys`, and `/public-ip` endpoint (description + params on the left, an interactive "Try it" panel on the right) with example responses and a "Try it" button that calls the live API using the configured `API_BASE_URL` (or the current origin); when `HEALTH_ENDPOINT_TOKEN` is set, an `X-Health-Token` input appears for protected monitoring calls.
+- **Debug page**: `/debug` shows the background poller's recent activity (persisted in the `poller_log` table, not just in-memory - so it survives worker restarts), filterable by event type (`poll_started`, device/key success or error, `public_ip_unchanged`, `public_ip_updated`, `public_ip_error`, notification events, `poll_completed`, and `poll_skipped`); capture is controlled by `DEBUG_LOG_ENABLED`, retention by `POLLER_LOG_RETENTION_DAYS` (default 7).
 - **Connectivity banner**: if the background poller's most recent cycle failed - especially with a 401/403 (bad/missing/revoked credentials) - the dashboard and `/admin/settings` show a banner pointing at the fix, driven by real poll outcomes (`GET /health`'s `poll_meta.last_poll_auth_error`) rather than a frontend guess.
 - **Health endpoint token generator**: `/admin/settings` has a "Generate" button next to the `HEALTH_ENDPOINT_TOKEN` field that fills in a securely random value (server-generated via `POST /admin/api/settings/generate-token`) - it only takes effect once you save the form.
+
+### Public-IP posture synchronization
+
+The **Public IP** sidebar page at `/admin/public-ip` manages multiple DynDNS hostname → posture-rule mappings in the same table-oriented style as the Devices page. Each row shows its latest DNS address, policy address, health state, timestamps, error, and backup reference. Administrators can search/filter mappings, enable or disable them, synchronize one mapping, or synchronize all enabled mappings.
+
+- Enter the posture rule name with or without `posture:`; the application adds the prefix automatically. The named posture must contain exactly one string condition using `ip:publicAddress == 'IPv4'` or `ip:publicAddress != 'IPv4'`.
+- Scheduled synchronization runs with the normal background poll cycle when **Enable public-IP updater** is enabled in the dedicated **DynDNS Posture Updater** card at `/admin/settings`. Manual synchronization remains available while scheduling is disabled.
+- A batch resolves all selected hostnames before writing anything, downloads the current HuJSON policy, changes only the mapped IPv4 tokens, validates the candidate through Tailscale, saves the previous policy, and uploads with its ETag. A failure aborts the batch rather than partially updating mappings.
+- Mapping edits are serialized with synchronization. If a sync is already running, create/edit/delete requests return `409` and the UI asks the administrator to retry, preventing stale mapping data from being recorded as healthy.
+- Backups are stored in `public-ip-policy-backups` beside `DATABASE_PATH`, with restricted permissions. `PUBLIC_IP_BACKUP_RETENTION_DAYS` controls retention; pruning occurs when a changed policy creates a new backup.
+- Enable **Public-IP errors affect overall health** to include enabled mapping errors in `/health`'s `global_healthy` result and its historical Overview graph. `/public-ip` always reports the independent public-IP counters regardless of that choice.
+- Enable the `public_ip_changed` notification event under Notifications to receive one message after each accepted address change, including the posture rule, hostname, and old/new IP. Device tag include/exclude filters do not apply because mappings are not devices and have no tags.
+- Synchronization requires Tailscale policy-file write permission. Monitoring-only installations and installations that leave both scheduled and manual synchronization unused do not need that permission.
+- Automatic changes and administrator CRUD operations appear in the audit log; operational unchanged/update/error events appear on `/debug` when debug-log capture is enabled.
 
 ### Response Metrics
 
@@ -411,6 +476,8 @@ The API response includes the following health metrics:
 - `counter_key_healthy_true/false`: Number of devices with valid/expiring keys
 - `counter_update_healthy_true/false`: Number of devices considered up to date / needing an update. Devices exempted by the `*_UPDATE_HEALTHY` filters count as up to date here.
 - `counter_lock_healthy_true/false`: Number of devices signed / awaiting a Tailnet Lock signature (always fully "true" unless `TAILNET_LOCK_ENABLED` is on)
+- `counter_public_ip_mapping_healthy/error/pending`: Enabled posture mappings grouped by their latest synchronization state
+- `total_public_ip_mappings`: Number of enabled mappings included in health computation
 
 **Global Health Metrics:**
 - `global_healthy`: True if `counter_healthy_false` is at or below `GLOBAL_HEALTHY_THRESHOLD`
@@ -418,6 +485,8 @@ The API response includes the following health metrics:
 - `global_key_healthy`: True if `counter_key_healthy_false` is at or below `GLOBAL_KEY_HEALTHY_THRESHOLD`
 - `global_update_healthy`: True if `counter_update_healthy_false` is at or below `GLOBAL_UPDATE_HEALTHY_THRESHOLD`
 - `global_lock_healthy`: True if `counter_lock_healthy_false` is at or below `GLOBAL_LOCK_HEALTHY_THRESHOLD`
+- `public_ip_updater_healthy`: True when no enabled mapping has a synchronization error
+- `public_ip_updater_affects_health`: Whether public-IP errors participate in `global_healthy`
 
 Each global metric has its own threshold (all default to `100`) and flips to `false` once its
 false-counter rises **above** that threshold. `/keys` reports a separate `global_keys_healthy`,

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ The application is configured using environment variables:
 | `APPRISE_API_URL`    | `""`              | Base URL of an already-running [Apprise API](https://github.com/caronc/apprise-api) instance to alert through, e.g. `http://apprise:8000`. Leave blank (with `APPRISE_NOTIFICATION_URLS`) to keep alerting off - this app doesn't bundle the `apprise` library itself, it just POSTs to that instance's stateless endpoint. |
 | `APPRISE_NOTIFICATION_URLS` | `""`       | One or more Apprise service URLs (comma-separated), e.g. `tgram://bottoken/ChatID`, `mailto://user:pass@host`, `slack://...` - sent straight through on every notification, no server-side config needed. |
 | `APPRISE_BEARER_TOKEN` | `""`            | Optional - only if the Apprise API instance itself requires bearer-token auth. Unrelated to the notification URLs above. |
-| `NOTIFICATION_EVENTS`| `""`              | Comma-separated subset of: `device_unhealthy`, `device_healthy_again`, `key_expiring`, `device_needs_signing`, `device_signed`, `global_unhealthy`, `global_healthy_restored`, `poll_auth_error`. Only listed events actually notify; empty means none do. |
+| `NOTIFICATION_EVENTS`| `""`              | Comma-separated subset of: `device_unhealthy`, `device_healthy_again`, `key_expiring`, `device_needs_signing`, `device_signed`, `global_unhealthy`, `global_healthy_restored`, `poll_auth_error`, `public_ip_changed`. Only listed events actually notify; empty means none do. |
 | `NOTIFY_INCLUDE_TAGS`| `""`              | Comma-separated, wildcard tag patterns scoping which devices' transitions notify (the four `device_*`/`key_expiring`... events above that are per-device; global/poll events aren't device-scoped, so this doesn't affect them). |
 | `NOTIFY_EXCLUDE_TAGS`| `""`              | Same, but exclude. `NOTIFY_INCLUDE_TAGS` takes precedence if both are set. |
 | `PORT`               | `5000`            | The port the application runs on. Process bootstrap only - not part of the settings registry, not editable via `/admin/settings`. |
@@ -363,7 +363,8 @@ Notes:
 - Alerts fire through an already-running [Apprise API](https://github.com/caronc/apprise-api) instance's *stateless* endpoint - this app POSTs `{urls, title, body}` to `<APPRISE_API_URL>/notify` after each poll cycle. It does not bundle the `apprise` Python library and needs no server-side config: `APPRISE_NOTIFICATION_URLS` carries the actual Apprise service URL(s) (e.g. `tgram://`, `mailto://`, `slack://`) directly.
 - Off by default: leave `APPRISE_API_URL`/`APPRISE_NOTIFICATION_URLS` blank, or `NOTIFICATION_EVENTS` empty, and nothing fires.
 - Fires once per *transition*, not on every poll cycle while a condition persists - e.g. a device staying unhealthy for an hour notifies once, not every `POLL_INTERVAL_SECONDS`. Nothing notifies on a device/key's first-ever appearance (avoids a notification storm on rollout).
-- `NOTIFY_INCLUDE_TAGS`/`NOTIFY_EXCLUDE_TAGS` scope the four per-device event types (`device_unhealthy`, `device_healthy_again`, `device_needs_signing`, `device_signed`) to a subset of devices; `global_unhealthy`, `global_healthy_restored`, `key_expiring`, and `poll_auth_error` aren't device-scoped and always notify regardless of these filters.
+- `NOTIFY_INCLUDE_TAGS`/`NOTIFY_EXCLUDE_TAGS` scope the four per-device event types (`device_unhealthy`, `device_healthy_again`, `device_needs_signing`, `device_signed`) to a subset of devices; `global_unhealthy`, `global_healthy_restored`, `key_expiring`, `poll_auth_error`, and `public_ip_changed` aren't device-scoped and always notify regardless of these filters.
+- `public_ip_changed` sends one notification per changed mapping after Tailscale accepts the updated policy, including the posture rule, DynDNS hostname, and old/new public addresses.
 - `device_needs_signing`/`device_signed` only fire when `TAILNET_LOCK_ENABLED=YES`, same as the rest of Tailnet Lock's behavior.
 - A failed delivery (Apprise instance unreachable, etc.) is logged as a `notification_failed` event on the `/debug` page rather than retried - it won't block or slow down polling.
 - `NOTIFICATION_COOLDOWN_MINUTES` (default `0`, off) sets a minimum gap between two notifications for the same event + device/key pair. Transitions already don't re-alert while a condition persists, but a device *flapping* across the healthy line alerts once per flap; a cooldown collapses those into one per window. Suppressed alerts appear on `/debug` as `notification_suppressed` events, so a quiet period is visibly a cooldown rather than a broken notifier.
@@ -449,6 +450,7 @@ To use OAuth, you need to create a Tailscale OAuth client with the required perm
 2. Click **Create OAuth Client** and configure the following:
    - **Name**: Provide a descriptive name for the client (e.g., `Tailscale Healthcheck`).
    - **Permissions**: Grant `read` permissions on `devices:core`. If you also want [tailnet key expiry monitoring](#keys) (`/keys`), additionally grant `read` on **API Access Tokens** and `read` on **Auth Keys**.
+   - **Public-IP updater**: Only when enabling DynDNS public-IP posture synchronization (including manual sync), also grant write access to the tailnet policy file. Monitoring-only installations do not need this permission.
 
 3. Copy the generated **Client ID** and **Client Secret**.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 ## ✨ Description
 
-A Python-based Flask application to monitor the health of devices in a Tailscale network. The application provides endpoints to check the health status of all devices, specific devices, and lists of healthy or unhealthy devices.
+A Tailscale monitoring and administration application with a React dashboard, health APIs, background polling, audit history, alerting, and policy automation. It tracks device and key health, exposes monitoring-friendly endpoints, and provides authenticated tools for operating a tailnet. The backend is implemented with Python and Flask.
 
 > Release notes have moved to the [GitHub Releases page](https://github.com/laitco/tailscale-healthcheck/releases).
 
@@ -103,6 +103,10 @@ A Python-based Flask application to monitor the health of devices in a Tailscale
   - Debug page (`/debug`) showing the background poller's recent activity log (persisted, not in-memory), filterable by event type
   - A visible banner on the dashboard and settings page when the poller can't reach the Tailscale API, calling out auth-credential problems specifically
   - User profile page (`/admin/profile`): change password, and enroll/disable TOTP-based two-factor authentication (with one-time recovery codes shown on enrollment); MFA-enabled accounts get a second login step
+- **DynDNS Public-IP Posture Automation**:
+  - Manage multiple DynDNS hostname → `ip:publicAddress` posture-rule mappings from `/admin/public-ip`
+  - Atomic HuJSON validation and ETag-protected policy updates with local policy backups
+  - Per-mapping status and manual synchronization, with optional inclusion in overall health
 - **Tailnet Key Filters**: `INCLUDE_KEY_TYPE`/`EXCLUDE_KEY_TYPE`/`INCLUDE_KEY_DESCRIPTION`/`EXCLUDE_KEY_DESCRIPTION` narrow which tailnet API/auth keys are reported, mirroring the device filters below.
 
 ## 📡 Endpoints
@@ -243,6 +247,9 @@ The application is configured using environment variables:
 | `POLL_INTERVAL_SECONDS` | `60`           | How often the background poller refreshes devices/tailnet keys from the Tailscale API into SQLite. |
 | `AUDIT_RETENTION_DAYS` | `14`            | How long audit log entries are kept before being purged. Also editable via `/admin/settings`. |
 | `POLLER_LOG_RETENTION_DAYS` | `7`         | How long the poller's operational activity log (shown on `/debug`) is kept before being purged. Also editable via `/admin/settings`. |
+| `PUBLIC_IP_UPDATER_ENABLED` | `NO`        | Enable scheduled synchronization of mappings configured on `/admin/public-ip`. |
+| `PUBLIC_IP_BACKUP_RETENTION_DAYS` | `30`  | Retain updater-created HuJSON policy backups for this many days under the database directory. |
+| `PUBLIC_IP_ERRORS_AFFECT_HEALTH` | `NO`   | Make an enabled mapping's latest synchronization error affect `global_healthy`. |
 | `HEALTH_ENDPOINT_TOKEN` | `""` (disabled) | Optional shared secret guarding the public `/health` endpoint. When set, requests must include a matching `X-Health-Token` header or get `401`. Also editable via `/admin/settings`. |
 | `TRUSTED_PROXY_COUNT` | `0`              | Number of reverse proxies in front of the app. `0` trusts nothing and uses the direct peer address; set it to your real proxy count (usually `1`) so per-IP rate limits and the failed-login lockout key off the actual client. Needs a restart. See [Security](#security). |
 | `SESSION_COOKIE_SECURE` | `NO`           | Add the `Secure` flag to the admin session cookie. Set `YES` when serving over HTTPS. Needs a restart. |

--- a/admin.py
+++ b/admin.py
@@ -24,6 +24,7 @@ from flask_login import current_user, login_required, login_user, logout_user
 import dbstore
 import poller
 import notifier
+import public_ip_updater
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 
@@ -580,6 +581,9 @@ def api_public_ip_status():
 @admin_bp.route("/api/public-ip/mappings", methods=["POST"])
 @login_required
 def api_create_public_ip_mapping():
+    lock = public_ip_updater.try_lock()
+    if lock is None:
+        return jsonify({"error": "A public-IP synchronization is in progress; try again shortly."}), 409
     try:
         hostname, posture_name, enabled = _validated_public_ip_mapping(request.get_json(silent=True) or {})
         mapping = dbstore.create_public_ip_mapping(hostname, posture_name, enabled, actor=current_user.username)
@@ -587,12 +591,17 @@ def api_create_public_ip_mapping():
         return jsonify({"error": str(exc)}), 400
     except sqlite3.IntegrityError:
         return jsonify({"error": "That posture rule already has a mapping"}), 409
+    finally:
+        public_ip_updater.release_lock(lock)
     return jsonify({"ok": True, "mapping": mapping}), 201
 
 
 @admin_bp.route("/api/public-ip/mappings/<int:mapping_id>", methods=["PUT"])
 @login_required
 def api_update_public_ip_mapping(mapping_id):
+    lock = public_ip_updater.try_lock()
+    if lock is None:
+        return jsonify({"error": "A public-IP synchronization is in progress; try again shortly."}), 409
     try:
         hostname, posture_name, enabled = _validated_public_ip_mapping(request.get_json(silent=True) or {})
         mapping = dbstore.update_public_ip_mapping(
@@ -602,6 +611,8 @@ def api_update_public_ip_mapping(mapping_id):
         return jsonify({"error": str(exc)}), 400
     except sqlite3.IntegrityError:
         return jsonify({"error": "That posture rule already has a mapping"}), 409
+    finally:
+        public_ip_updater.release_lock(lock)
     if mapping is None:
         return jsonify({"error": "Mapping not found"}), 404
     return jsonify({"ok": True, "mapping": mapping})
@@ -610,9 +621,15 @@ def api_update_public_ip_mapping(mapping_id):
 @admin_bp.route("/api/public-ip/mappings/<int:mapping_id>", methods=["DELETE"])
 @login_required
 def api_delete_public_ip_mapping(mapping_id):
-    if not dbstore.delete_public_ip_mapping(mapping_id, actor=current_user.username):
-        return jsonify({"error": "Mapping not found"}), 404
-    return jsonify({"ok": True})
+    lock = public_ip_updater.try_lock()
+    if lock is None:
+        return jsonify({"error": "A public-IP synchronization is in progress; try again shortly."}), 409
+    try:
+        if not dbstore.delete_public_ip_mapping(mapping_id, actor=current_user.username):
+            return jsonify({"error": "Mapping not found"}), 404
+        return jsonify({"ok": True})
+    finally:
+        public_ip_updater.release_lock(lock)
 
 
 @admin_bp.route("/api/public-ip/sync", methods=["POST"])

--- a/admin.py
+++ b/admin.py
@@ -12,7 +12,9 @@ app that legitimately needs POST/DELETE.
 """
 import logging
 import os
+import re
 import secrets
+import sqlite3
 import time
 
 import requests
@@ -150,6 +152,12 @@ def login_page():
 @login_required
 def settings_page():
     return render_template("admin_settings.html")
+
+
+@admin_bp.route("/public-ip", methods=["GET"])
+@login_required
+def public_ip_page():
+    return render_template("admin_public_ip.html")
 
 
 @admin_bp.route("/profile", methods=["GET"])
@@ -543,6 +551,84 @@ def api_poll_now():
     return jsonify({"ok": True, "last_polled_at": dbstore.get_poll_meta()})
 
 
+def _validated_public_ip_mapping(data):
+    hostname = str(data.get("hostname", "")).strip().rstrip(".").lower()
+    posture_name = str(data.get("posture_name", "")).strip()
+    if posture_name and not posture_name.startswith("posture:"):
+        posture_name = f"posture:{posture_name}"
+    enabled = bool(data.get("enabled", True))
+    if not hostname or len(hostname) > 253 or not re.fullmatch(
+        r"(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", hostname
+    ):
+        raise ValueError("A valid DynDNS hostname is required")
+    if not posture_name.startswith("posture:") or len(posture_name) <= len("posture:"):
+        raise ValueError("posture_name must start with posture: and include a name")
+    return hostname, posture_name, enabled
+
+
+@admin_bp.route("/api/public-ip", methods=["GET"])
+@login_required
+def api_public_ip_status():
+    settings = dbstore.get_settings_typed((
+        "public_ip_updater_enabled", "public_ip_backup_retention_days",
+        "public_ip_errors_affect_health", "poll_interval_seconds",
+    ))
+    mappings = dbstore.list_public_ip_mappings()
+    return jsonify({"settings": settings, "mappings": mappings})
+
+
+@admin_bp.route("/api/public-ip/mappings", methods=["POST"])
+@login_required
+def api_create_public_ip_mapping():
+    try:
+        hostname, posture_name, enabled = _validated_public_ip_mapping(request.get_json(silent=True) or {})
+        mapping = dbstore.create_public_ip_mapping(hostname, posture_name, enabled, actor=current_user.username)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except sqlite3.IntegrityError:
+        return jsonify({"error": "That posture rule already has a mapping"}), 409
+    return jsonify({"ok": True, "mapping": mapping}), 201
+
+
+@admin_bp.route("/api/public-ip/mappings/<int:mapping_id>", methods=["PUT"])
+@login_required
+def api_update_public_ip_mapping(mapping_id):
+    try:
+        hostname, posture_name, enabled = _validated_public_ip_mapping(request.get_json(silent=True) or {})
+        mapping = dbstore.update_public_ip_mapping(
+            mapping_id, hostname, posture_name, enabled, actor=current_user.username
+        )
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except sqlite3.IntegrityError:
+        return jsonify({"error": "That posture rule already has a mapping"}), 409
+    if mapping is None:
+        return jsonify({"error": "Mapping not found"}), 404
+    return jsonify({"ok": True, "mapping": mapping})
+
+
+@admin_bp.route("/api/public-ip/mappings/<int:mapping_id>", methods=["DELETE"])
+@login_required
+def api_delete_public_ip_mapping(mapping_id):
+    if not dbstore.delete_public_ip_mapping(mapping_id, actor=current_user.username):
+        return jsonify({"error": "Mapping not found"}), 404
+    return jsonify({"ok": True})
+
+
+@admin_bp.route("/api/public-ip/sync", methods=["POST"])
+@admin_bp.route("/api/public-ip/mappings/<int:mapping_id>/sync", methods=["POST"])
+@login_required
+def api_sync_public_ip(mapping_id=None):
+    result = poller.run_public_ip_sync(mapping_id=mapping_id, actor=current_user.username)
+    if result.get("busy"):
+        return jsonify(result), 202
+    if result.get("not_found"):
+        return jsonify(result), 404
+    if not result.get("ok"):
+        return jsonify(result), 502
+    return jsonify(result)
+
+
 @admin_bp.route("/api/users", methods=["GET"])
 @login_required
 def api_list_users():
@@ -613,7 +699,7 @@ def api_audit_filters():
         "actors": dbstore.list_audit_log_actors(),
         "changed_fields": dbstore.list_audit_log_changed_fields(entity_type),
         "entity_ids": dbstore.list_audit_log_entity_ids(entity_type),
-        "entity_types": ["device", "tailnet_key", "setting", "user"],
+        "entity_types": ["device", "tailnet_key", "setting", "user", "public_ip_mapping"],
         "actions": ["created", "updated", "removed"],
     })
 

--- a/dbstore.py
+++ b/dbstore.py
@@ -939,14 +939,10 @@ def set_public_ip_mapping_result(mapping_id: int, *, status: str, resolved_ip=No
         )
 
 
-def audit_public_ip_sync(mapping_id: int, posture_name: str, hostname: str,
-                         old_ip: str, new_ip: str, backup: str, actor: str):
+def audit_public_ip_sync(mapping_id: int, old_ip: str, new_ip: str, actor: str = None):
     with get_connection() as conn:
         _add_audit(conn, "public_ip_mapping", str(mapping_id), "updated", {
-            "posture_name": {"old": posture_name, "new": posture_name},
-            "hostname": {"old": hostname, "new": hostname},
             "public_ip": {"old": old_ip, "new": new_ip},
-            "backup": {"old": None, "new": backup},
         }, actor=actor)
 
 

--- a/dbstore.py
+++ b/dbstore.py
@@ -146,6 +146,12 @@ SETTINGS_REGISTRY = {
     # not the compliance-flavored audit_log, so it gets its own knob.
     "poller_log_retention_days": ("POLLER_LOG_RETENTION_DAYS", "int", 7, None, "poll"),
 
+    # DynDNS -> ip:publicAddress posture updater. Individual hostname/posture
+    # mappings live in public_ip_mappings; these are the global controls.
+    "public_ip_updater_enabled": ("PUBLIC_IP_UPDATER_ENABLED", "bool", False, None, "public_ip"),
+    "public_ip_backup_retention_days": ("PUBLIC_IP_BACKUP_RETENTION_DAYS", "int", 30, None, "public_ip"),
+    "public_ip_errors_affect_health": ("PUBLIC_IP_ERRORS_AFFECT_HEALTH", "bool", False, None, "public_ip"),
+
     # Alerting via an externally-hosted Apprise API instance's *stateless*
     # /notify endpoint (not the apprise Python library, and no server-side
     # config key needed - see notifier.py). Empty api_url/notification_urls
@@ -358,7 +364,9 @@ def init_db():
                 counter_update_healthy_true INTEGER,
                 counter_update_healthy_false INTEGER,
                 keys_counter_healthy_true INTEGER,
-                keys_counter_healthy_false INTEGER
+                keys_counter_healthy_false INTEGER,
+                public_ip_mapping_healthy INTEGER NOT NULL DEFAULT 0,
+                public_ip_mapping_error INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_metrics_history_occurred_at ON metrics_history(occurred_at);
 
@@ -417,6 +425,25 @@ def init_db():
                 last_notified_at TEXT NOT NULL,
                 PRIMARY KEY (event_type, entity_id)
             );
+
+            CREATE TABLE IF NOT EXISTS public_ip_mappings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                hostname TEXT NOT NULL,
+                posture_name TEXT NOT NULL UNIQUE,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_checked_at TEXT,
+                last_success_at TEXT,
+                last_changed_at TEXT,
+                resolved_ip TEXT,
+                configured_ip TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                last_error TEXT,
+                last_backup TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_public_ip_mappings_enabled
+                ON public_ip_mappings(enabled);
             """
         )
         # users table predates totp_secret/totp_enabled - add them for
@@ -431,6 +458,11 @@ def init_db():
         existing_device_columns = {row["name"] for row in conn.execute("PRAGMA table_info(devices)")}
         if "tailnet_lock_error" not in existing_device_columns:
             conn.execute("ALTER TABLE devices ADD COLUMN tailnet_lock_error TEXT")
+        existing_metrics_columns = {row["name"] for row in conn.execute("PRAGMA table_info(metrics_history)")}
+        if "public_ip_mapping_healthy" not in existing_metrics_columns:
+            conn.execute("ALTER TABLE metrics_history ADD COLUMN public_ip_mapping_healthy INTEGER NOT NULL DEFAULT 0")
+        if "public_ip_mapping_error" not in existing_metrics_columns:
+            conn.execute("ALTER TABLE metrics_history ADD COLUMN public_ip_mapping_error INTEGER NOT NULL DEFAULT 0")
 
 
 # ---------------------------------------------------------------------------
@@ -617,6 +649,8 @@ def validate_setting_value(name: str, raw: str):
             caster(raw)
         except (TypeError, ValueError):
             raise ValueError(f"{name} must be a valid {type_name}")
+    if name == "public_ip_backup_retention_days" and int(raw) < 1:
+        raise ValueError("public_ip_backup_retention_days must be at least 1")
     return encode_setting_value(name, raw)
 
 
@@ -805,6 +839,115 @@ def release_manual_poll_claim():
     out the crash-recovery TTL."""
     with get_connection() as conn:
         conn.execute("DELETE FROM settings WHERE name = 'manual_poll_claimed_until'")
+
+
+# ---------------------------------------------------------------------------
+# DynDNS public-IP posture mappings
+# ---------------------------------------------------------------------------
+
+def _public_ip_mapping_dict(row):
+    if row is None:
+        return None
+    item = dict(row)
+    item["enabled"] = bool(item["enabled"])
+    return item
+
+
+def list_public_ip_mappings(enabled_only: bool = False):
+    sql = "SELECT * FROM public_ip_mappings"
+    params = ()
+    if enabled_only:
+        sql += " WHERE enabled = 1"
+    sql += " ORDER BY posture_name COLLATE NOCASE, id"
+    with get_connection() as conn:
+        return [_public_ip_mapping_dict(row) for row in conn.execute(sql, params).fetchall()]
+
+
+def get_public_ip_mapping(mapping_id: int):
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM public_ip_mappings WHERE id = ?", (mapping_id,)).fetchone()
+    return _public_ip_mapping_dict(row)
+
+
+def create_public_ip_mapping(hostname: str, posture_name: str, enabled: bool = True, actor: str = None):
+    now = _now_iso()
+    with get_connection() as conn:
+        cur = conn.execute(
+            "INSERT INTO public_ip_mappings "
+            "(hostname, posture_name, enabled, created_at, updated_at, status) "
+            "VALUES (?, ?, ?, ?, ?, 'pending')",
+            (hostname, posture_name, int(bool(enabled)), now, now),
+        )
+        mapping_id = cur.lastrowid
+        _add_audit(conn, "public_ip_mapping", str(mapping_id), "created", {
+            "hostname": {"old": None, "new": hostname},
+            "posture_name": {"old": None, "new": posture_name},
+            "enabled": {"old": None, "new": bool(enabled)},
+        }, actor=actor)
+    return get_public_ip_mapping(mapping_id)
+
+
+def update_public_ip_mapping(mapping_id: int, hostname: str, posture_name: str,
+                             enabled: bool, actor: str = None):
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM public_ip_mappings WHERE id = ?", (mapping_id,)).fetchone()
+        if row is None:
+            return None
+        changes = {}
+        for key, new in (("hostname", hostname), ("posture_name", posture_name), ("enabled", bool(enabled))):
+            old = bool(row[key]) if key == "enabled" else row[key]
+            if old != new:
+                changes[key] = {"old": old, "new": new}
+        reset = row["hostname"] != hostname or row["posture_name"] != posture_name
+        conn.execute(
+            "UPDATE public_ip_mappings SET hostname = ?, posture_name = ?, enabled = ?, updated_at = ?, "
+            "status = CASE WHEN ? THEN 'pending' ELSE status END, "
+            "last_error = CASE WHEN ? THEN NULL ELSE last_error END WHERE id = ?",
+            (hostname, posture_name, int(bool(enabled)), _now_iso(), int(reset), int(reset), mapping_id),
+        )
+        if changes:
+            _add_audit(conn, "public_ip_mapping", str(mapping_id), "updated", changes, actor=actor)
+    return get_public_ip_mapping(mapping_id)
+
+
+def delete_public_ip_mapping(mapping_id: int, actor: str = None):
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM public_ip_mappings WHERE id = ?", (mapping_id,)).fetchone()
+        if row is None:
+            return False
+        conn.execute("DELETE FROM public_ip_mappings WHERE id = ?", (mapping_id,))
+        _add_audit(conn, "public_ip_mapping", str(mapping_id), "removed", {
+            "hostname": {"old": row["hostname"], "new": None},
+            "posture_name": {"old": row["posture_name"], "new": None},
+        }, actor=actor)
+    return True
+
+
+def set_public_ip_mapping_result(mapping_id: int, *, status: str, resolved_ip=None,
+                                 configured_ip=None, error=None, backup=None,
+                                 success: bool = False, changed: bool = False):
+    now = _now_iso()
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE public_ip_mappings SET last_checked_at = ?, status = ?, last_error = ?, "
+            "resolved_ip = COALESCE(?, resolved_ip), configured_ip = COALESCE(?, configured_ip), "
+            "last_backup = COALESCE(?, last_backup), "
+            "last_success_at = CASE WHEN ? THEN ? ELSE last_success_at END, "
+            "last_changed_at = CASE WHEN ? THEN ? ELSE last_changed_at END WHERE id = ?",
+            (now, status, error, resolved_ip, configured_ip, backup,
+             int(success), now, int(changed), now, mapping_id),
+        )
+
+
+def audit_public_ip_sync(mapping_id: int, posture_name: str, hostname: str,
+                         old_ip: str, new_ip: str, backup: str, actor: str):
+    with get_connection() as conn:
+        _add_audit(conn, "public_ip_mapping", str(mapping_id), "updated", {
+            "posture_name": posture_name,
+            "hostname": hostname,
+            "public_ip": {"old": old_ip, "new": new_ip},
+            "backup": backup,
+        }, actor=actor)
 
 
 def set_poll_status(ok: bool, error: str = None, auth_error: bool = False):
@@ -1576,6 +1719,7 @@ METRICS_HISTORY_COLUMNS = (
     "counter_key_healthy_true", "counter_key_healthy_false",
     "counter_update_healthy_true", "counter_update_healthy_false",
     "keys_counter_healthy_true", "keys_counter_healthy_false",
+    "public_ip_mapping_healthy", "public_ip_mapping_error",
 )
 
 
@@ -1597,6 +1741,8 @@ def record_metrics_snapshot(health_metrics: dict, keys_metrics: dict):
         "counter_update_healthy_false": health_metrics.get("counter_update_healthy_false", 0),
         "keys_counter_healthy_true": keys_metrics.get("counter_key_healthy_true", 0),
         "keys_counter_healthy_false": keys_metrics.get("counter_key_healthy_false", 0),
+        "public_ip_mapping_healthy": health_metrics.get("counter_public_ip_mapping_healthy", 0),
+        "public_ip_mapping_error": health_metrics.get("counter_public_ip_mapping_error", 0),
     }
     with get_connection() as conn:
         conn.execute(

--- a/dbstore.py
+++ b/dbstore.py
@@ -943,10 +943,10 @@ def audit_public_ip_sync(mapping_id: int, posture_name: str, hostname: str,
                          old_ip: str, new_ip: str, backup: str, actor: str):
     with get_connection() as conn:
         _add_audit(conn, "public_ip_mapping", str(mapping_id), "updated", {
-            "posture_name": posture_name,
-            "hostname": hostname,
+            "posture_name": {"old": posture_name, "new": posture_name},
+            "hostname": {"old": hostname, "new": hostname},
             "public_ip": {"old": old_ip, "new": new_ip},
-            "backup": backup,
+            "backup": {"old": None, "new": backup},
         }, actor=actor)
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import AdminUsersPage from '@/pages/admin-users'
 import AdminProfilePage from '@/pages/admin-profile'
 import AdminAuditPage from '@/pages/admin-audit'
 import ApiDocsPage from '@/pages/api-docs'
+import PublicIpPage from '@/pages/public-ip'
 import { useSystemTheme } from '@/lib/use-system-theme'
 import { HealthProvider } from '@/lib/health-context'
 import { ErrorBoundary } from '@/components/error-boundary'
@@ -50,6 +51,7 @@ export default function App() {
                   <Route path="/admin/profile" element={<AdminProfilePage />} />
                   <Route path="/admin/audit" element={<AdminAuditPage />} />
                   <Route path="/admin/api-docs" element={<ApiDocsPage />} />
+                  <Route path="/admin/public-ip" element={<PublicIpPage />} />
                   <Route path="*" element={<NotFoundPage />} />
                 </Routes>
                 </ErrorBoundary>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { LayoutDashboard, Laptop, KeyRound, Bug, Network, RefreshCw, Settings, Users, ScrollText, LogOut, BookOpen, UserCircle } from 'lucide-react'
+import { LayoutDashboard, Laptop, KeyRound, Bug, Network, RefreshCw, Settings, Users, ScrollText, LogOut, BookOpen, UserCircle, Globe2 } from 'lucide-react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import {
   Sidebar,
@@ -54,6 +54,7 @@ const navItems = [
 ]
 
 const adminItems = [
+  { to: '/admin/public-ip', label: 'Public IP', icon: Globe2 },
   { to: '/admin/settings', label: 'Settings', icon: Settings },
   { to: '/admin/users', label: 'Users', icon: Users },
   { to: '/admin/audit', label: 'Audit Log', icon: ScrollText },

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -14,6 +14,7 @@ const TITLES: { test: (path: string) => boolean; title: string }[] = [
   { test: (p) => p === '/admin/users', title: 'Users' },
   { test: (p) => p === '/admin/audit', title: 'Audit Log' },
   { test: (p) => p === '/admin/api-docs', title: 'API Docs' },
+  { test: (p) => p === '/admin/public-ip', title: 'Public IP' },
 ]
 
 function useTitle() {

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -114,6 +114,52 @@ export function pollNow(): Promise<{ ok: boolean; last_polled_at: string | null 
   return request('/admin/api/poll-now', { method: 'POST' })
 }
 
+export type PublicIpMapping = {
+  id: number
+  hostname: string
+  posture_name: string
+  enabled: boolean
+  status: 'pending' | 'healthy' | 'error'
+  last_checked_at: string | null
+  last_success_at: string | null
+  last_changed_at: string | null
+  resolved_ip: string | null
+  configured_ip: string | null
+  last_error: string | null
+  last_backup: string | null
+}
+
+export type PublicIpStatus = {
+  settings: {
+    public_ip_updater_enabled: boolean
+    public_ip_backup_retention_days: number
+    public_ip_errors_affect_health: boolean
+    poll_interval_seconds: number
+  }
+  mappings: PublicIpMapping[]
+}
+
+export function fetchPublicIpStatus(): Promise<PublicIpStatus> {
+  return request('/admin/api/public-ip')
+}
+
+export function createPublicIpMapping(payload: { hostname: string; posture_name: string; enabled: boolean }) {
+  return request('/admin/api/public-ip/mappings', { method: 'POST', body: JSON.stringify(payload) })
+}
+
+export function updatePublicIpMapping(id: number, payload: { hostname: string; posture_name: string; enabled: boolean }) {
+  return request(`/admin/api/public-ip/mappings/${id}`, { method: 'PUT', body: JSON.stringify(payload) })
+}
+
+export function deletePublicIpMapping(id: number) {
+  return request(`/admin/api/public-ip/mappings/${id}`, { method: 'DELETE' })
+}
+
+export function syncPublicIp(id?: number): Promise<{ ok: boolean; changed: number; message?: string; error?: string }> {
+  const path = id == null ? '/admin/api/public-ip/sync' : `/admin/api/public-ip/mappings/${id}/sync`
+  return request(path, { method: 'POST' })
+}
+
 export function testNotification(overrides: Record<string, string>): Promise<{ ok: true }> {
   return request('/admin/api/notifications/test', { method: 'POST', body: JSON.stringify(overrides) })
 }
@@ -184,6 +230,8 @@ export type MetricsHistoryEntry = {
   counter_update_healthy_false: number
   keys_counter_healthy_true: number
   keys_counter_healthy_false: number
+  public_ip_mapping_healthy: number
+  public_ip_mapping_error: number
 }
 
 export function fetchMetricsHistory(hours = 24): Promise<{ entries: MetricsHistoryEntry[] }> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -50,6 +50,14 @@ export interface HealthMetrics {
   global_key_healthy: boolean
   global_update_healthy: boolean
   global_lock_healthy: boolean
+  device_global_healthy: boolean
+  public_ip_updater_enabled: boolean
+  public_ip_updater_healthy: boolean
+  public_ip_updater_affects_health: boolean
+  counter_public_ip_mapping_healthy: number
+  counter_public_ip_mapping_error: number
+  counter_public_ip_mapping_pending: number
+  total_public_ip_mappings: number
   counter_healthy_online_true: number
   counter_healthy_online_false: number
   counter_key_healthy_true: number

--- a/frontend/src/pages/admin-settings.tsx
+++ b/frontend/src/pages/admin-settings.tsx
@@ -18,7 +18,7 @@ import type { SettingField, SettingsResponse } from '@/lib/types'
 type FieldDef = { name: string; label: string; unit?: string; help?: string; generatable?: boolean }
 
 const GROUP_ORDER = [
-  'connection', 'thresholds', 'filters', 'notifications', 'general', 'security', 'logging', 'rate_limit', 'retry', 'poll',
+  'connection', 'thresholds', 'filters', 'notifications', 'public_ip', 'general', 'security', 'logging', 'rate_limit', 'retry', 'poll',
 ] as const
 
 const GROUP_LABELS: Record<string, string> = {
@@ -26,6 +26,7 @@ const GROUP_LABELS: Record<string, string> = {
   thresholds: 'Health Thresholds',
   filters: 'Filters',
   notifications: 'Notifications',
+  public_ip: 'DynDNS Posture Updater',
   general: 'General',
   security: 'Security',
   logging: 'Logging',
@@ -39,6 +40,7 @@ const GROUP_DESCRIPTIONS: Record<string, string> = {
   thresholds: 'Control when devices and the overall tailnet are considered healthy.',
   filters: 'Comma-separated glob patterns (e.g. tag:prod, *.example.com). Press Enter or comma to add an entry.',
   notifications: 'Alert via an already-running Apprise API instance (apprise-api) - channel setup (Slack, email, ...) lives on that instance, not here.',
+  public_ip: 'Global controls for DynDNS-to-posture mappings managed on the Public IP page.',
   general: 'Miscellaneous behavior settings.',
   security: 'Session and reverse-proxy handling. All three take effect only after a process restart.',
   logging: 'Application log verbosity.',
@@ -147,6 +149,11 @@ const FIELDS_BY_GROUP: Record<string, FieldDef[]> = {
       unit: 'minutes',
       help: 'Minimum gap between two notifications for the same event and device/key. Alerts already only fire on a transition, but a device flapping across the healthy line still alerts once per flap - a cooldown collapses those into one. 0 disables it. Suppressed alerts show on the Debug page as notification_suppressed events.',
     },
+  ],
+  public_ip: [
+    { name: 'public_ip_updater_enabled', label: 'Enable public-IP updater', help: 'Check every enabled DynDNS mapping during each normal poll cycle.' },
+    { name: 'public_ip_backup_retention_days', label: 'Policy backup retention', unit: 'days', help: 'Delete updater-created policy backups older than this many days.' },
+    { name: 'public_ip_errors_affect_health', label: 'Include updater errors in overall health', help: 'When on, any enabled mapping whose latest synchronization failed makes overall health unhealthy.' },
   ],
   general: [
     { name: 'timezone', label: 'Timezone', help: "IANA timezone (e.g. Europe/Berlin) used for lastSeen and key-expiry timestamps shown throughout the app." },

--- a/frontend/src/pages/admin-settings.tsx
+++ b/frontend/src/pages/admin-settings.tsx
@@ -313,6 +313,7 @@ const NOTIFICATION_EVENT_OPTIONS: { value: string; label: string }[] = [
   { value: 'global_unhealthy', label: 'Overall tailnet becomes unhealthy' },
   { value: 'global_healthy_restored', label: 'Overall tailnet becomes healthy again' },
   { value: 'poll_auth_error', label: "Tailscale API credentials aren't working" },
+  { value: 'public_ip_changed', label: 'DynDNS public IP changes' },
 ]
 
 export default function AdminSettingsPage() {

--- a/frontend/src/pages/api-docs.tsx
+++ b/frontend/src/pages/api-docs.tsx
@@ -151,6 +151,43 @@ const ENDPOINTS: EndpointDef[] = [
   },
   {
     method: 'GET',
+    path: '/public-ip',
+    group: 'Public IP',
+    description: 'DynDNS posture-mapping health, resolved and configured addresses, timestamps, and aggregate status.',
+    authNote:
+      'Unauthenticated by default. If HEALTH_ENDPOINT_TOKEN is configured, requests must include an X-Health-Token header matching it.',
+    example: {
+      mappings: [
+        {
+          id: 1,
+          hostname: 'home.example.net',
+          posture_name: 'posture:Home',
+          enabled: true,
+          status: 'healthy',
+          healthy: true,
+          resolved_ip: '203.0.113.10',
+          configured_ip: '203.0.113.10',
+          last_checked_at: '2026-08-11T20:15:00Z',
+          last_success_at: '2026-08-11T20:15:00Z',
+          last_changed_at: '2026-08-10T08:30:00Z',
+          last_error: null,
+        },
+      ],
+      metrics: {
+        updater_enabled: true,
+        errors_affect_health: true,
+        global_public_ip_healthy: true,
+        total_mappings: 1,
+        enabled_mappings: 1,
+        counter_mapping_healthy: 1,
+        counter_mapping_error: 0,
+        counter_mapping_pending: 0,
+      },
+      poll_meta: { last_polled_at: '2026-08-11T20:15:00Z', poll_interval_seconds: 60 },
+    },
+  },
+  {
+    method: 'GET',
     path: '/health/cache/invalidate',
     group: 'Operations',
     description: 'Clears the response cache and triggers an immediate poll of the Tailscale API.',
@@ -170,7 +207,7 @@ interface TryState {
 
 // Only /health (and its trailing-slash form /health/) is ever unauthenticated by
 // default, so it's the only endpoint the health-endpoint-token field applies to.
-const HEALTH_TOKEN_ENDPOINTS = new Set(['/health'])
+const HEALTH_TOKEN_ENDPOINTS = new Set(['/health', '/public-ip'])
 
 export default function ApiDocsPage() {
   const [baseUrl, setBaseUrl] = useState<string | null>(null)

--- a/frontend/src/pages/overview.tsx
+++ b/frontend/src/pages/overview.tsx
@@ -86,12 +86,23 @@ export default function OverviewPage() {
           </Button>
         </Alert>
       )}
+      {metrics.public_ip_updater_enabled && !metrics.public_ip_updater_healthy && (
+        <Alert className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="font-medium">Public-IP posture synchronization failing</p>
+            <p className="text-xs text-destructive/90">
+              {metrics.counter_public_ip_mapping_error} enabled mapping{metrics.counter_public_ip_mapping_error === 1 ? '' : 's'} need attention.
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm"><Link to="/admin/public-ip">Review mappings</Link></Button>
+        </Alert>
+      )}
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 2xl:grid-cols-3">
         <MetricCard
           title="Overall Health"
           value={metrics.global_healthy ? 'Healthy' : 'Issues'}
-          subtitle={`${metrics.counter_healthy_false} issue${metrics.counter_healthy_false === 1 ? '' : 's'} · trend below`}
+          subtitle={`${metrics.counter_healthy_false} device issue${metrics.counter_healthy_false === 1 ? '' : 's'}${metrics.counter_public_ip_mapping_error ? ` · ${metrics.counter_public_ip_mapping_error} public-IP issue${metrics.counter_public_ip_mapping_error === 1 ? '' : 's'}` : ''} · trend below`}
           ok={metrics.global_healthy}
           // Plot the positive (healthy) count, same convention as every
           // other tile below (up = good) - keeps all trend charts reading
@@ -145,6 +156,29 @@ export default function OverviewPage() {
             trendTimezone={timezone}
           />
         )}
+        <MetricCard
+          title="DynDNS Posture Health"
+          value={
+            !metrics.public_ip_updater_enabled
+              ? 'Disabled'
+              : metrics.total_public_ip_mappings === 0
+                ? 'Not Configured'
+                : `${metrics.counter_public_ip_mapping_healthy} / ${metrics.total_public_ip_mappings}`
+          }
+          subtitle={
+            !metrics.public_ip_updater_enabled
+              ? 'Enable in Settings'
+              : metrics.counter_public_ip_mapping_error
+                ? `${metrics.counter_public_ip_mapping_error} synchronization error${metrics.counter_public_ip_mapping_error === 1 ? '' : 's'}`
+                : metrics.counter_public_ip_mapping_pending
+                  ? `${metrics.counter_public_ip_mapping_pending} mapping${metrics.counter_public_ip_mapping_pending === 1 ? '' : 's'} pending first check`
+                  : 'All checked mappings healthy'
+          }
+          ok={metrics.public_ip_updater_enabled ? metrics.public_ip_updater_healthy : undefined}
+          trend={trend((e) => e.public_ip_mapping_healthy)}
+          trendTimestamps={timestamps}
+          trendTimezone={timezone}
+        />
       </section>
     </div>
   )

--- a/frontend/src/pages/public-ip.tsx
+++ b/frontend/src/pages/public-ip.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Plus, RefreshCw } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { StatusBadge } from '@/components/status-badge'
+import {
+  createPublicIpMapping,
+  deletePublicIpMapping,
+  errorMessage,
+  fetchPublicIpStatus,
+  syncPublicIp,
+  updatePublicIpMapping,
+  type PublicIpMapping,
+  type PublicIpStatus,
+} from '@/lib/admin-api'
+import { relativeTime } from '@/lib/format'
+import { useNow } from '@/lib/use-now'
+import { useToast } from '@/lib/toast'
+
+const EMPTY = { hostname: '', posture_name: 'PublicAddress', enabled: true }
+const ALL = '__all__'
+
+function displayPosture(name: string) {
+  return name.replace(/^posture:/, '')
+}
+
+function MappingStatus({ mapping }: { mapping: PublicIpMapping }) {
+  if (!mapping.enabled) return <Badge variant="outline">Disabled</Badge>
+  if (mapping.status === 'pending') return <Badge variant="secondary">Pending</Badge>
+  return <StatusBadge ok={mapping.status === 'healthy'} trueText="Healthy" falseText="Error" />
+}
+
+export default function PublicIpPage() {
+  const [data, setData] = useState<PublicIpStatus | null>(null)
+  const [form, setForm] = useState(EMPTY)
+  const [editing, setEditing] = useState<number | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [search, setSearch] = useState('')
+  const [status, setStatus] = useState(ALL)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const { notify } = useToast()
+  useNow(30000)
+
+  async function load() {
+    try {
+      setData(await fetchPublicIpStatus())
+      setError('')
+    } catch (err) {
+      setError(errorMessage(err, 'Failed to load public-IP mappings'))
+    }
+  }
+
+  useEffect(() => { void load() }, [])
+
+  async function submit() {
+    setBusy(true)
+    try {
+      if (editing == null) await createPublicIpMapping(form)
+      else await updatePublicIpMapping(editing, form)
+      notify(editing == null ? 'Mapping added.' : 'Mapping updated.')
+      setForm(EMPTY)
+      setEditing(null)
+      setShowForm(false)
+      await load()
+    } catch (err) {
+      notify(errorMessage(err, 'Failed to save mapping'), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function beginEdit(mapping: PublicIpMapping) {
+    setEditing(mapping.id)
+    setForm({ hostname: mapping.hostname, posture_name: displayPosture(mapping.posture_name), enabled: mapping.enabled })
+    setShowForm(true)
+  }
+
+  async function remove(mapping: PublicIpMapping) {
+    if (!window.confirm(`Delete the mapping for ${displayPosture(mapping.posture_name)}?`)) return
+    setBusy(true)
+    try {
+      await deletePublicIpMapping(mapping.id)
+      await load()
+      notify('Mapping deleted.')
+    } catch (err) {
+      notify(errorMessage(err, 'Failed to delete mapping'), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function sync(id?: number) {
+    setBusy(true)
+    try {
+      const result = await syncPublicIp(id)
+      await load()
+      notify(result.changed ? `Updated ${result.changed} posture rule(s).` : result.message || 'Already current.')
+    } catch (err) {
+      await load()
+      notify(errorMessage(err, 'Public-IP synchronization failed'), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    return (data?.mappings ?? []).filter((mapping) => {
+      if (query && !`${mapping.hostname} ${mapping.posture_name} ${mapping.resolved_ip || ''} ${mapping.configured_ip || ''}`.toLowerCase().includes(query)) return false
+      if (status === 'enabled' && !mapping.enabled) return false
+      if (status === 'disabled' && mapping.enabled) return false
+      if (status === 'healthy' && (!mapping.enabled || mapping.status !== 'healthy')) return false
+      if (status === 'error' && (!mapping.enabled || mapping.status !== 'error')) return false
+      if (status === 'pending' && (!mapping.enabled || mapping.status !== 'pending')) return false
+      return true
+    })
+  }, [data, search, status])
+
+  if (!data) return <Alert>{error || 'Loading public-IP mappings…'}</Alert>
+
+  return (
+    <div className="space-y-4">
+      {error && <Alert>{error}</Alert>}
+      {!data.settings.public_ip_updater_enabled && (
+        <Alert className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="font-medium">DynDNS posture updates are disabled</p>
+            <p className="text-xs text-muted-foreground">Mappings remain available for manual synchronization.</p>
+          </div>
+          <Button asChild variant="outline" size="sm"><Link to="/admin/settings">Open settings</Link></Button>
+        </Alert>
+      )}
+
+      <section className="flex flex-wrap items-center gap-2">
+        <Input placeholder="Search posture, hostname, or IP" value={search} onChange={(event) => setSearch(event.target.value)} className="max-w-xs" />
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger className="w-40"><SelectValue placeholder="All status" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All status</SelectItem>
+            <SelectItem value="healthy">Healthy</SelectItem>
+            <SelectItem value="error">Error</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="enabled">Enabled</SelectItem>
+            <SelectItem value="disabled">Disabled</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="flex-1" />
+        <Button variant="outline" disabled={busy || !data.mappings.some((mapping) => mapping.enabled)} onClick={() => void sync()}>
+          <RefreshCw className={busy ? 'animate-spin' : ''} /> Sync all
+        </Button>
+        <Button onClick={() => { setEditing(null); setForm(EMPTY); setShowForm(true) }}><Plus /> Add mapping</Button>
+      </section>
+
+      {showForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{editing == null ? 'Add mapping' : 'Edit mapping'}</CardTitle>
+            <CardDescription>The posture: prefix is added automatically.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-[1fr_1fr_auto] md:items-end">
+            <label className="space-y-1 text-sm">DynDNS hostname
+              <Input value={form.hostname} placeholder="home.example.net" onChange={(event) => setForm({ ...form, hostname: event.target.value })} />
+            </label>
+            <label className="space-y-1 text-sm">Posture rule name
+              <Input value={form.posture_name} placeholder="PublicAddress" onChange={(event) => setForm({ ...form, posture_name: event.target.value.replace(/^posture:/, '') })} />
+            </label>
+            <div className="flex gap-2">
+              <Button disabled={busy || !form.hostname || !form.posture_name} onClick={() => void submit()}>{editing == null ? 'Add' : 'Save'}</Button>
+              <Button variant="outline" onClick={() => { setShowForm(false); setEditing(null); setForm(EMPTY) }}>Cancel</Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Status</TableHead>
+              <TableHead>Posture Rule</TableHead>
+              <TableHead>DynDNS Hostname</TableHead>
+              <TableHead>DNS IP</TableHead>
+              <TableHead>Policy IP</TableHead>
+              <TableHead>Last Checked</TableHead>
+              <TableHead>Last Changed</TableHead>
+              <TableHead>Backup</TableHead>
+              <TableHead>Enabled</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 && (
+              <TableRow><TableCell colSpan={10} className="text-center text-muted-foreground">No mappings match your filters.</TableCell></TableRow>
+            )}
+            {filtered.map((mapping) => (
+              <TableRow key={mapping.id}>
+                <TableCell><MappingStatus mapping={mapping} /></TableCell>
+                <TableCell className="font-medium">{displayPosture(mapping.posture_name)}</TableCell>
+                <TableCell>{mapping.hostname}</TableCell>
+                <TableCell>{mapping.resolved_ip || '—'}</TableCell>
+                <TableCell>{mapping.configured_ip || '—'}</TableCell>
+                <TableCell title={mapping.last_checked_at || undefined}>{mapping.last_checked_at ? relativeTime(mapping.last_checked_at) : 'Never'}</TableCell>
+                <TableCell title={mapping.last_changed_at || undefined}>{mapping.last_changed_at ? relativeTime(mapping.last_changed_at) : 'Never'}</TableCell>
+                <TableCell className="max-w-48 truncate" title={mapping.last_backup || undefined}>{mapping.last_backup || '—'}</TableCell>
+                <TableCell>
+                  <Switch checked={mapping.enabled} disabled={busy} aria-label={`Enable ${displayPosture(mapping.posture_name)}`}
+                    onCheckedChange={(enabled) => void updatePublicIpMapping(mapping.id, { hostname: mapping.hostname, posture_name: displayPosture(mapping.posture_name), enabled }).then(load)} />
+                </TableCell>
+                <TableCell>
+                  <div className="flex justify-end gap-1">
+                    <Button size="sm" variant="outline" disabled={busy || !mapping.enabled} onClick={() => void sync(mapping.id)}>Sync</Button>
+                    <Button size="sm" variant="outline" disabled={busy} onClick={() => beginEdit(mapping)}>Edit</Button>
+                    <Button size="sm" variant="destructive" disabled={busy} onClick={() => void remove(mapping)}>Delete</Button>
+                  </div>
+                  {mapping.last_error && <p className="mt-1 max-w-72 whitespace-normal text-right text-xs text-destructive" title={mapping.last_error}>{mapping.last_error}</p>}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <p className="text-xs text-muted-foreground">Showing {filtered.length} of {data.mappings.length} mappings.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/public-ip.tsx
+++ b/frontend/src/pages/public-ip.tsx
@@ -111,6 +111,23 @@ export default function PublicIpPage() {
     }
   }
 
+  async function setMappingEnabled(mapping: PublicIpMapping, enabled: boolean) {
+    setBusy(true)
+    try {
+      await updatePublicIpMapping(mapping.id, {
+        hostname: mapping.hostname,
+        posture_name: displayPosture(mapping.posture_name),
+        enabled,
+      })
+      await load()
+    } catch (err) {
+      await load()
+      notify(errorMessage(err, 'Failed to update mapping'), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const filtered = useMemo(() => {
     const query = search.trim().toLowerCase()
     return (data?.mappings ?? []).filter((mapping) => {
@@ -212,7 +229,7 @@ export default function PublicIpPage() {
                 <TableCell className="max-w-48 truncate" title={mapping.last_backup || undefined}>{mapping.last_backup || '—'}</TableCell>
                 <TableCell>
                   <Switch checked={mapping.enabled} disabled={busy} aria-label={`Enable ${displayPosture(mapping.posture_name)}`}
-                    onCheckedChange={(enabled) => void updatePublicIpMapping(mapping.id, { hostname: mapping.hostname, posture_name: displayPosture(mapping.posture_name), enabled }).then(load)} />
+                    onCheckedChange={(enabled) => void setMappingEnabled(mapping, enabled)} />
                 </TableCell>
                 <TableCell>
                   <div className="flex justify-end gap-1">

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -765,6 +765,7 @@ HEALTH_SUMMARY_SETTINGS = (
     "global_healthy_threshold", "global_key_healthy_threshold",
     "global_online_healthy_threshold", "global_update_healthy_threshold",
     "tailnet_lock_enabled", "global_lock_healthy_threshold", "lock_signer_tags",
+    "public_ip_updater_enabled", "public_ip_errors_affect_health",
     "include_os", "exclude_os", "include_identifier", "exclude_identifier",
     "include_tags", "exclude_tags",
     "include_identifier_update_healthy", "exclude_identifier_update_healthy",
@@ -881,6 +882,15 @@ def _compute_health_summary(devices):
             health_info["keyExpiryTimestamp"] = expires.isoformat() if expires else None
         health_status.append(health_info)
 
+    public_ip_mappings = dbstore.list_public_ip_mappings(enabled_only=True) if cfg["public_ip_updater_enabled"] else []
+    public_ip_errors = sum(1 for mapping in public_ip_mappings if mapping["status"] == "error")
+    public_ip_pending = sum(1 for mapping in public_ip_mappings if mapping["status"] == "pending")
+    public_ip_healthy = public_ip_errors == 0
+    device_global_healthy = counter_healthy_false <= cfg["global_healthy_threshold"]
+    overall_healthy = device_global_healthy
+    if cfg["public_ip_updater_enabled"] and cfg["public_ip_errors_affect_health"]:
+        overall_healthy = overall_healthy and public_ip_healthy
+
     metrics = {
         "counter_healthy_true": counter_healthy_true,
         "counter_healthy_false": counter_healthy_false,
@@ -892,11 +902,19 @@ def _compute_health_summary(devices):
         "counter_update_healthy_false": counter_update_healthy_false,
         "counter_lock_healthy_true": counter_lock_healthy_true,
         "counter_lock_healthy_false": counter_lock_healthy_false,
-        "global_healthy": counter_healthy_false <= cfg["global_healthy_threshold"],
+        "global_healthy": overall_healthy,
+        "device_global_healthy": device_global_healthy,
         "global_key_healthy": counter_key_healthy_false <= cfg["global_key_healthy_threshold"],
         "global_online_healthy": counter_healthy_online_false <= cfg["global_online_healthy_threshold"],
         "global_update_healthy": counter_update_healthy_false <= cfg["global_update_healthy_threshold"],
         "global_lock_healthy": counter_lock_healthy_false <= cfg["global_lock_healthy_threshold"],
+        "public_ip_updater_enabled": cfg["public_ip_updater_enabled"],
+        "public_ip_updater_healthy": public_ip_healthy,
+        "public_ip_updater_affects_health": cfg["public_ip_errors_affect_health"],
+        "counter_public_ip_mapping_healthy": sum(1 for mapping in public_ip_mappings if mapping["status"] == "healthy"),
+        "counter_public_ip_mapping_error": public_ip_errors,
+        "counter_public_ip_mapping_pending": public_ip_pending,
+        "total_public_ip_mappings": len(public_ip_mappings),
     }
     return health_status, metrics
 
@@ -1194,6 +1212,53 @@ def keys_status():
     except Exception as e:
         logging.error(f"Error in keys_status: {e}")
         return jsonify({"error": str(e)}), 500
+
+
+@app.route('/public-ip', methods=['GET'])
+@_apply_limits
+def public_ip_status():
+    """Return DynDNS posture-mapping status for monitoring integrations."""
+    if not _health_endpoint_token_ok():
+        return jsonify({"error": "Unauthorized"}), 401
+    cfg = dbstore.get_settings_typed((
+        "public_ip_updater_enabled", "public_ip_errors_affect_health",
+    ))
+    stored = dbstore.list_public_ip_mappings()
+    mappings = []
+    for mapping in stored:
+        enabled = bool(mapping["enabled"])
+        mappings.append({
+            "id": mapping["id"],
+            "hostname": mapping["hostname"],
+            "posture_name": mapping["posture_name"],
+            "enabled": enabled,
+            "status": mapping["status"],
+            "healthy": None if not enabled else mapping["status"] != "error",
+            "resolved_ip": mapping["resolved_ip"],
+            "configured_ip": mapping["configured_ip"],
+            "last_checked_at": mapping["last_checked_at"],
+            "last_success_at": mapping["last_success_at"],
+            "last_changed_at": mapping["last_changed_at"],
+            "last_error": mapping["last_error"],
+        })
+    enabled_mappings = [mapping for mapping in mappings if mapping["enabled"]]
+    error_count = sum(1 for mapping in enabled_mappings if mapping["status"] == "error")
+    healthy_count = sum(1 for mapping in enabled_mappings if mapping["status"] == "healthy")
+    pending_count = sum(1 for mapping in enabled_mappings if mapping["status"] == "pending")
+    return jsonify({
+        "mappings": mappings,
+        "metrics": {
+            "updater_enabled": cfg["public_ip_updater_enabled"],
+            "errors_affect_health": cfg["public_ip_errors_affect_health"],
+            "global_public_ip_healthy": error_count == 0,
+            "total_mappings": len(stored),
+            "enabled_mappings": len(enabled_mappings),
+            "counter_mapping_healthy": healthy_count,
+            "counter_mapping_error": error_count,
+            "counter_mapping_pending": pending_count,
+        },
+        "poll_meta": _build_poll_meta(),
+    })
 
 @app.route('/health/', methods=['GET'])
 @_apply_limits

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -510,9 +510,9 @@ def _upstream_error_payload(e: "requests.exceptions.HTTPError"):
             pass
     return {"error": message, "upstream_status": status}, status
 
-def make_authenticated_request(url, headers):
+def make_authenticated_request(url, headers, method="GET", data=None, timeout=None):
     """
-    Make an authenticated GET request with bounded, iterative retries.
+    Make an authenticated request with bounded, iterative retries.
 
     - Retries only on transient connection errors (e.g., RemoteDisconnected, ProtocolError).
     - On 401, fetches a new OAuth token and retries once immediately within the same attempt.
@@ -532,20 +532,26 @@ def make_authenticated_request(url, headers):
     backoff_base = retry_cfg["backoff_base_seconds"]
     backoff_max = retry_cfg["backoff_max_seconds"]
     backoff_jitter = retry_cfg["backoff_jitter_seconds"]
+    request_timeout = get_http_timeout() if timeout is None else timeout
+
+    def issue_request():
+        if method == "GET" and data is None:
+            return requests.get(url, headers=headers, timeout=request_timeout)
+        return requests.request(method, url, headers=headers, data=data, timeout=request_timeout)
 
     last_err = None
     for attempt in range(1, max_retries + 1):
         try:
-            response = requests.get(url, headers=headers, timeout=get_http_timeout())
+            response = issue_request()
             if response.status_code == 401:
                 logging.error("Unauthorized error (401). Attempting to refresh OAuth token...")
                 fetch_oauth_token()
                 if ACCESS_TOKEN:
                     headers["Authorization"] = f"Bearer {ACCESS_TOKEN}"
-                    response = requests.get(url, headers=headers, timeout=get_http_timeout())
+                    response = issue_request()
             response.raise_for_status()
             return response
-        except (RemoteDisconnected, ProtocolError) as e:
+        except (RemoteDisconnected, ProtocolError, requests.exceptions.ConnectionError) as e:
             last_err = e
             if attempt >= max_retries:
                 break
@@ -565,7 +571,7 @@ def make_authenticated_request(url, headers):
             )
             time.sleep(sleep_for)
         except requests.exceptions.Timeout as to_err:
-            logging.warning(f"Timeout during external request after {get_http_timeout()}s: {to_err}")
+            logging.warning(f"Timeout during external request after {request_timeout}s: {to_err}")
             raise
         except Exception as e:
             logging.error(f"Error during authenticated request: {e}")

--- a/notifier.py
+++ b/notifier.py
@@ -31,6 +31,7 @@ EVENT_TYPES = (
     "global_unhealthy",
     "global_healthy_restored",
     "poll_auth_error",
+    "public_ip_changed",
 )
 
 NOTIFICATION_SETTINGS = (

--- a/poller.py
+++ b/poller.py
@@ -19,6 +19,7 @@ import requests
 
 import dbstore
 import notifier
+import public_ip_updater
 
 _lock_fh = None
 _timer = None
@@ -31,11 +32,12 @@ EVENT_TYPES = (
     "poll_skipped", "poll_started",
     "devices_success", "devices_error",
     "keys_success", "keys_error",
+    "public_ip_unchanged", "public_ip_updated", "public_ip_error",
     "notification_sent", "notification_failed", "notification_suppressed",
     "poll_completed",
 )
 
-_ERROR_EVENT_TYPES = {"devices_error", "keys_error", "notification_failed"}
+_ERROR_EVENT_TYPES = {"devices_error", "keys_error", "notification_failed", "public_ip_error"}
 
 
 def _record(event_type: str, message: str, detail: dict = None):
@@ -95,6 +97,35 @@ def poll_interval_seconds() -> int:
         return max(5, int(dbstore.get_setting_typed("poll_interval_seconds")))
     except (TypeError, ValueError):
         return 60
+
+
+def run_public_ip_sync(mapping_id: int = None, actor: str = "poller"):
+    """Run all enabled mappings or one selected mapping under a cross-worker lock."""
+    lock = public_ip_updater.try_lock()
+    if lock is None:
+        return {"ok": False, "busy": True, "message": "A public-IP sync is already in progress."}
+    try:
+        if mapping_id is None:
+            mappings = dbstore.list_public_ip_mappings(enabled_only=True)
+        else:
+            mapping = dbstore.get_public_ip_mapping(mapping_id)
+            if mapping is None:
+                return {"ok": False, "not_found": True, "error": "Mapping not found"}
+            mappings = [mapping]
+        import healthcheck
+        current_client_id = dbstore.get_setting("oauth_client_id")
+        if _needs_oauth_refresh(healthcheck, current_client_id):
+            healthcheck.fetch_oauth_token()
+        return public_ip_updater.sync(
+            mappings,
+            dbstore.get_setting("tailnet_domain"),
+            healthcheck.build_auth_header(),
+            healthcheck.get_http_timeout(),
+            actor=actor,
+            record=_record,
+        )
+    finally:
+        public_ip_updater.release_lock(lock)
 
 
 def _record_notification(event_type: str, target: str, sent: bool, reason: str):
@@ -348,6 +379,9 @@ def run_poll_cycle():
         cycle_error = cycle_error or str(e)
         cycle_auth_error = cycle_auth_error or _is_auth_error(e)
         _record("keys_error", f"Failed to fetch/store tailnet keys: {e}", {"error": str(e), "auth_error": _is_auth_error(e)})
+
+    if dbstore.get_setting_typed("public_ip_updater_enabled"):
+        run_public_ip_sync(actor="poller")
 
     was_auth_error = bool(previous_poll_status.get("auth_error"))
     dbstore.set_poll_status(ok=cycle_error is None, error=cycle_error, auth_error=cycle_auth_error)

--- a/poller.py
+++ b/poller.py
@@ -99,7 +99,7 @@ def poll_interval_seconds() -> int:
         return 60
 
 
-def run_public_ip_sync(mapping_id: int = None, actor: str = "poller"):
+def run_public_ip_sync(mapping_id: int = None, actor: str = None):
     """Run all enabled mappings or one selected mapping under a cross-worker lock."""
     lock = public_ip_updater.try_lock()
     if lock is None:
@@ -116,7 +116,7 @@ def run_public_ip_sync(mapping_id: int = None, actor: str = "poller"):
         current_client_id = dbstore.get_setting("oauth_client_id")
         if _needs_oauth_refresh(healthcheck, current_client_id):
             healthcheck.fetch_oauth_token()
-        return public_ip_updater.sync(
+        result = public_ip_updater.sync(
             mappings,
             dbstore.get_setting("tailnet_domain"),
             healthcheck.build_auth_header(),
@@ -124,6 +124,9 @@ def run_public_ip_sync(mapping_id: int = None, actor: str = "poller"):
             actor=actor,
             record=_record,
         )
+        if result.get("ok") and result.get("changes"):
+            _notify_public_ip_changes(result["changes"])
+        return result
     finally:
         public_ip_updater.release_lock(lock)
 
@@ -135,6 +138,23 @@ def _record_notification(event_type: str, target: str, sent: bool, reason: str):
         _record(
             "notification_failed", f"Failed to notify '{event_type}' for {target}: {reason}",
             {"event_type": event_type, "error": reason},
+        )
+
+
+def _notify_public_ip_changes(changes: list):
+    cfg = dbstore.get_settings_typed(notifier.NOTIFICATION_SETTINGS)
+    cooldown = dbstore.get_last_notified("public_ip_changed")
+    for change in changes:
+        mapping_id = str(change["mapping_id"])
+        target = change["posture_name"]
+        _notify_entity(
+            "public_ip_changed",
+            mapping_id,
+            target,
+            f"Public IP changed for {target}",
+            f"{change['hostname']} changed from {change['old_ip']} to {change['new_ip']}.",
+            cfg,
+            cooldown,
         )
 
 
@@ -277,6 +297,9 @@ def _process_global_notifications(cfg: dict, health_metrics: dict):
         event = "global_healthy_restored" if new_healthy else "global_unhealthy"
         title = "Tailnet is healthy again" if new_healthy else "Tailnet is unhealthy"
         body = f"{health_metrics.get('counter_healthy_false', 0)} device(s) currently unhealthy."
+        public_ip_errors = int(health_metrics.get("counter_public_ip_mapping_error", 0) or 0)
+        if public_ip_errors:
+            body += f" {public_ip_errors} public-IP posture mapping(s) have synchronization errors."
         _notify_entity(event, "tailnet", "tailnet", title, body, cfg, dbstore.get_last_notified(event))
     dbstore.set_health_state("global", "tailnet", new_healthy)
 
@@ -381,7 +404,7 @@ def run_poll_cycle():
         _record("keys_error", f"Failed to fetch/store tailnet keys: {e}", {"error": str(e), "auth_error": _is_auth_error(e)})
 
     if dbstore.get_setting_typed("public_ip_updater_enabled"):
-        run_public_ip_sync(actor="poller")
+        run_public_ip_sync()
 
     was_auth_error = bool(previous_poll_status.get("auth_error"))
     dbstore.set_poll_status(ok=cycle_error is None, error=cycle_error, auth_error=cycle_auth_error)

--- a/public_ip_updater.py
+++ b/public_ip_updater.py
@@ -1,0 +1,331 @@
+"""Synchronize DynDNS IPv4 addresses into Tailscale posture rules.
+
+The Tailscale policy is HuJSON, so this module tokenizes just enough of the
+document to replace the address inside a named posture without normalizing or
+rewriting any unrelated bytes.
+"""
+from __future__ import annotations
+
+import fcntl
+import ipaddress
+import json
+import os
+import re
+import socket
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import requests
+
+import dbstore
+
+
+API_BASE = "https://api.tailscale.com/api/v2"
+RULE_RE = re.compile(r"^(\s*ip:publicAddress\s*(?:==|!=)\s*')([^']+)('\s*)$")
+BACKUP_PREFIX = "tailscale-policy-"
+
+
+class UpdateError(Exception):
+    """A safe, expected synchronization failure."""
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: str
+    value: str
+    start: int
+    end: int
+
+
+def validate_public_ipv4(value: str, source: str) -> str:
+    try:
+        address = ipaddress.ip_address(value.strip())
+    except ValueError as exc:
+        raise UpdateError(f"{source} returned an invalid IP address: {value!r}") from exc
+    if address.version != 4 or not address.is_global:
+        raise UpdateError(f"{source} returned a non-public IPv4 address: {address}")
+    return str(address)
+
+
+def resolve_public_ipv4(hostname: str) -> str:
+    try:
+        answers = socket.getaddrinfo(hostname, None, socket.AF_INET, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UpdateError(f"DNS lookup for {hostname!r} failed: {exc}") from exc
+    public = []
+    for value in sorted({answer[4][0] for answer in answers}, key=ipaddress.ip_address):
+        try:
+            public.append(validate_public_ipv4(value, f"DNS hostname {hostname!r}"))
+        except UpdateError:
+            continue
+    if not public:
+        raise UpdateError(f"DNS hostname {hostname!r} returned no public IPv4 address")
+    return public[0]
+
+
+def _decode_json_string(raw: str) -> str:
+    try:
+        value = json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        raise UpdateError(f"Invalid string token in policy: {raw[:80]!r}") from exc
+    if not isinstance(value, str):
+        raise UpdateError("Internal parser error: expected a string")
+    return value
+
+
+def tokens(text: str) -> list[Token]:
+    result = []
+    i = 0
+    while i < len(text):
+        char = text[i]
+        if char.isspace():
+            i += 1
+        elif text.startswith("//", i):
+            newline = text.find("\n", i + 2)
+            i = len(text) if newline < 0 else newline + 1
+        elif text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            if end < 0:
+                raise UpdateError("Unterminated block comment in HuJSON policy")
+            i = end + 2
+        elif char == '"':
+            start = i
+            i += 1
+            while i < len(text):
+                if text[i] == "\\":
+                    i += 2
+                elif text[i] == '"':
+                    i += 1
+                    break
+                else:
+                    i += 1
+            else:
+                raise UpdateError("Unterminated string in HuJSON policy")
+            result.append(Token("string", _decode_json_string(text[start:i]), start, i))
+        elif char in "{}[]:,":
+            result.append(Token(char, char, i, i + 1))
+            i += 1
+        else:
+            start = i
+            while i < len(text) and not text[i].isspace() and text[i] not in '{}[]:,"':
+                if text.startswith("//", i) or text.startswith("/*", i):
+                    break
+                i += 1
+            if start == i:
+                raise UpdateError(f"Unexpected character at policy offset {i}")
+            result.append(Token("bare", text[start:i], start, i))
+    return result
+
+
+def _find_matching(items, start, opening, closing):
+    depth = 0
+    for index in range(start, len(items)):
+        if items[index].kind == opening:
+            depth += 1
+        elif items[index].kind == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    raise UpdateError(f"Unbalanced {opening}{closing} in policy")
+
+
+def _object_members(items, start, end):
+    members = []
+    i = start + 1
+    while i < end:
+        if items[i].kind == ",":
+            i += 1
+            continue
+        if items[i].kind != "string" or i + 1 >= end or items[i + 1].kind != ":":
+            raise UpdateError(f"Malformed HuJSON object near offset {items[i].start}")
+        value_start = i + 2
+        if value_start >= end:
+            raise UpdateError("Missing value in HuJSON object")
+        kind = items[value_start].kind
+        value_end = _find_matching(items, value_start, kind, "}" if kind == "{" else "]") if kind in ("{", "[") else value_start
+        members.append((items[i].value, value_start, value_end))
+        i = value_end + 1
+        if i < end and items[i].kind == ",":
+            i += 1
+    return members
+
+
+def locate_rule(text: str, posture_name: str):
+    items = tokens(text)
+    if not items or items[0].kind != "{":
+        raise UpdateError("Policy root is not a HuJSON object")
+    root_end = _find_matching(items, 0, "{", "}")
+    if root_end != len(items) - 1:
+        raise UpdateError("Unexpected content after policy root object")
+    sections = [(a, b) for key, a, b in _object_members(items, 0, root_end) if key == "postures"]
+    if len(sections) != 1:
+        raise UpdateError(f"Top-level 'postures' must exist exactly once; found {len(sections)}")
+    postures_start, postures_end = sections[0]
+    if items[postures_start].kind != "{":
+        raise UpdateError("Top-level 'postures' value is not an object")
+    matches = [(a, b) for key, a, b in _object_members(items, postures_start, postures_end) if key == posture_name]
+    if len(matches) != 1:
+        raise UpdateError(f"{posture_name!r} must exist exactly once; found {len(matches)}")
+    array_start, array_end = matches[0]
+    if items[array_start].kind != "[":
+        raise UpdateError(f"{posture_name!r} must be an array")
+    values = [token for token in items[array_start + 1:array_end] if token.kind != ","]
+    if len(values) != 1 or values[0].kind != "string":
+        raise UpdateError(f"{posture_name!r} must contain exactly one string rule")
+    match = RULE_RE.fullmatch(values[0].value)
+    if not match:
+        raise UpdateError(f"{posture_name!r} must contain exactly one ip:publicAddress == or != rule")
+    old_ip = validate_public_ipv4(match.group(2), "Configured posture rule")
+    raw = text[values[0].start:values[0].end]
+    offset = raw.find(match.group(2))
+    if offset < 0 or raw.count(match.group(2)) != 1:
+        raise UpdateError("Could not uniquely locate the configured IP token")
+    start = values[0].start + offset
+    return old_ip, start, start + len(match.group(2))
+
+
+def update_rules(policy: str, replacements: dict[str, str]):
+    located = []
+    old_ips = {}
+    for posture_name, new_ip in replacements.items():
+        validate_public_ipv4(new_ip, "New address")
+        old_ip, start, end = locate_rule(policy, posture_name)
+        located.append((start, end, new_ip))
+        old_ips[posture_name] = old_ip
+    changed = policy
+    for start, end, new_ip in sorted(located, reverse=True):
+        changed = changed[:start] + new_ip + changed[end:]
+    for posture_name, new_ip in replacements.items():
+        verified, _start, _end = locate_rule(changed, posture_name)
+        if verified != new_ip:
+            raise UpdateError(f"Post-update verification failed for {posture_name!r}")
+    return old_ips, changed
+
+
+def _backup_dir():
+    return Path(dbstore.DATABASE_PATH).parent / "public-ip-policy-backups"
+
+
+def backup_policy(policy: bytes, retention_days: int) -> Path:
+    directory = _backup_dir()
+    try:
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+        path = directory / f"{BACKUP_PREFIX}{timestamp}.hujson"
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(policy)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        cutoff = datetime.now(timezone.utc) - timedelta(days=max(1, retention_days))
+        for candidate in directory.iterdir():
+            if not candidate.name.startswith(BACKUP_PREFIX) or candidate.suffix != ".hujson" or candidate.is_symlink():
+                continue
+            if candidate.is_file() and datetime.fromtimestamp(candidate.stat().st_mtime, timezone.utc) < cutoff:
+                candidate.unlink()
+    except OSError as exc:
+        raise UpdateError(f"Could not create or prune policy backups: {exc}") from exc
+    return path
+
+
+def _api_request(method, url, auth_headers, timeout, body=None, content_type=None, etag=None):
+    headers = dict(auth_headers)
+    headers.update({"Accept": "application/hujson", "User-Agent": "tailscale-healthcheck/1"})
+    if content_type:
+        headers["Content-Type"] = content_type
+    if etag:
+        headers["If-Match"] = etag
+    try:
+        response = requests.request(method, url, headers=headers, data=body, timeout=timeout)
+        response.raise_for_status()
+        return response
+    except requests.RequestException as exc:
+        detail = ""
+        if getattr(exc, "response", None) is not None:
+            detail = exc.response.text[:4096].strip()
+        raise UpdateError(f"Tailscale API {method} failed: {detail or exc}") from exc
+
+
+def _lock_path():
+    return str(Path(dbstore.DATABASE_PATH).parent / "public-ip-updater.lock")
+
+
+def try_lock():
+    handle = open(_lock_path(), "w")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return handle
+    except (BlockingIOError, OSError):
+        handle.close()
+        return None
+
+
+def release_lock(handle):
+    if handle:
+        handle.close()
+
+
+def sync(mappings, tailnet: str, auth_headers: dict, timeout: float, actor="poller", record=None):
+    """Synchronize a supplied mapping batch. The caller owns serialization."""
+    if not mappings:
+        return {"ok": True, "changed": 0, "message": "No enabled mappings."}
+    resolved = {}
+    try:
+        for mapping in mappings:
+            resolved[mapping["id"]] = resolve_public_ipv4(mapping["hostname"])
+        url = f"{API_BASE}/tailnet/{requests.utils.quote(tailnet, safe='')}/acl"
+        response = _api_request("GET", url, auth_headers, timeout)
+        policy_bytes = response.content
+        if not policy_bytes:
+            raise UpdateError("Tailscale returned an empty policy")
+        policy = policy_bytes.decode("utf-8")
+        replacements = {mapping["posture_name"]: resolved[mapping["id"]] for mapping in mappings}
+        old_ips, candidate = update_rules(policy, replacements)
+        changed_mappings = [m for m in mappings if old_ips[m["posture_name"]] != resolved[m["id"]]]
+        if not changed_mappings:
+            for mapping in mappings:
+                ip = resolved[mapping["id"]]
+                dbstore.set_public_ip_mapping_result(mapping["id"], status="healthy", resolved_ip=ip,
+                                                     configured_ip=ip, success=True)
+            if record:
+                record("public_ip_unchanged", f"Public-IP posture mappings already current ({len(mappings)} checked).")
+            return {"ok": True, "changed": 0, "message": "All mappings already current."}
+        etag = response.headers.get("ETag")
+        if not etag:
+            raise UpdateError("Tailscale response did not contain an ETag")
+        candidate_bytes = candidate.encode("utf-8")
+        _api_request("POST", url + "/validate", auth_headers, timeout, candidate_bytes, "application/hujson")
+        retention = dbstore.get_setting_typed("public_ip_backup_retention_days")
+        backup = backup_policy(policy_bytes, retention)
+        _api_request("POST", url, auth_headers, timeout, candidate_bytes, "application/hujson", etag)
+        for mapping in mappings:
+            mapping_id = mapping["id"]
+            new_ip = resolved[mapping_id]
+            old_ip = old_ips[mapping["posture_name"]]
+            changed = old_ip != new_ip
+            dbstore.set_public_ip_mapping_result(
+                mapping_id, status="healthy", resolved_ip=new_ip, configured_ip=new_ip,
+                backup=backup.name if changed else None, success=True, changed=changed,
+            )
+            if changed:
+                dbstore.audit_public_ip_sync(mapping_id, mapping["posture_name"], mapping["hostname"],
+                                             old_ip, new_ip, backup.name, actor)
+        if record:
+            record("public_ip_updated", f"Updated {len(changed_mappings)} public-IP posture mapping(s).",
+                   {"changed": len(changed_mappings), "backup": backup.name})
+        return {"ok": True, "changed": len(changed_mappings), "backup": backup.name}
+    except Exception as exc:
+        message = str(exc) if isinstance(exc, (UpdateError, UnicodeDecodeError)) else f"Unexpected failure: {exc}"
+        for mapping in mappings:
+            mapping_error = message if mapping["id"] not in resolved else f"Batch aborted: {message}"
+            dbstore.set_public_ip_mapping_result(mapping["id"], status="error",
+                                                 resolved_ip=resolved.get(mapping["id"]), error=mapping_error)
+        if record:
+            record("public_ip_error", f"Public-IP posture synchronization failed: {message}", {"error": message})
+        return {"ok": False, "changed": 0, "error": message}

--- a/public_ip_updater.py
+++ b/public_ip_updater.py
@@ -242,10 +242,11 @@ def _api_request(method, url, auth_headers, timeout, body=None, content_type=Non
     if etag:
         headers["If-Match"] = etag
     try:
-        response = requests.request(method, url, headers=headers, data=body, timeout=timeout)
-        response.raise_for_status()
-        return response
-    except requests.RequestException as exc:
+        import healthcheck  # Deferred to avoid the healthcheck -> poller -> updater import cycle.
+        return healthcheck.make_authenticated_request(
+            url, headers, method=method, data=body, timeout=timeout,
+        )
+    except (requests.RequestException, RuntimeError) as exc:
         detail = ""
         if getattr(exc, "response", None) is not None:
             detail = exc.response.text[:4096].strip()
@@ -271,7 +272,7 @@ def release_lock(handle):
         handle.close()
 
 
-def sync(mappings, tailnet: str, auth_headers: dict, timeout: float, actor="poller", record=None):
+def sync(mappings, tailnet: str, auth_headers: dict, timeout: float, actor=None, record=None):
     """Synchronize a supplied mapping batch. The caller owns serialization."""
     if not mappings:
         return {"ok": True, "changed": 0, "message": "No enabled mappings."}
@@ -314,12 +315,26 @@ def sync(mappings, tailnet: str, auth_headers: dict, timeout: float, actor="poll
                 backup=backup.name if changed else None, success=True, changed=changed,
             )
             if changed:
-                dbstore.audit_public_ip_sync(mapping_id, mapping["posture_name"], mapping["hostname"],
-                                             old_ip, new_ip, backup.name, actor)
+                dbstore.audit_public_ip_sync(mapping_id, old_ip, new_ip, actor)
+        changes = [
+            {
+                "mapping_id": mapping["id"],
+                "posture_name": mapping["posture_name"],
+                "hostname": mapping["hostname"],
+                "old_ip": old_ips[mapping["posture_name"]],
+                "new_ip": resolved[mapping["id"]],
+            }
+            for mapping in changed_mappings
+        ]
         if record:
             record("public_ip_updated", f"Updated {len(changed_mappings)} public-IP posture mapping(s).",
                    {"changed": len(changed_mappings), "backup": backup.name})
-        return {"ok": True, "changed": len(changed_mappings), "backup": backup.name}
+        return {
+            "ok": True,
+            "changed": len(changed_mappings),
+            "changes": changes,
+            "backup": backup.name,
+        }
     except Exception as exc:
         message = str(exc) if isinstance(exc, (UpdateError, UnicodeDecodeError)) else f"Unexpected failure: {exc}"
         for mapping in mappings:

--- a/templates/admin_public_ip.html
+++ b/templates/admin_public_ip.html
@@ -1,0 +1,2 @@
+{% extends 'layout.html' %}
+{% block title %}Public IP • Tailscale Healthcheck{% endblock %}

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -565,3 +565,34 @@ def test_audit_api_exposes_change_filters(configured):
     filters = client.get("/admin/api/audit/filters").get_json()
     assert "os" in filters["changed_fields"]
     assert "client_version" in filters["changed_fields"]
+
+
+def test_public_ip_mapping_api_crud_and_manual_sync(configured):
+    configured.dbstore.create_user("admin", "correct-horse-battery-staple")
+    client = configured.app.test_client()
+    client.post("/admin/api/login", json={
+        "username": "admin", "password": "correct-horse-battery-staple",
+    })
+
+    created = client.post("/admin/api/public-ip/mappings", json={
+        "hostname": "Home.Example.NET.",
+        "posture_name": "Home",
+        "enabled": True,
+    })
+    assert created.status_code == 201
+    mapping = created.get_json()["mapping"]
+    assert mapping["hostname"] == "home.example.net"
+    assert mapping["posture_name"] == "posture:Home"
+
+    duplicate = client.post("/admin/api/public-ip/mappings", json={
+        "hostname": "other.example.net", "posture_name": "posture:Home",
+    })
+    assert duplicate.status_code == 409
+
+    with patch("admin.poller.run_public_ip_sync", return_value={"ok": True, "changed": 0}) as sync:
+        response = client.post(f"/admin/api/public-ip/mappings/{mapping['id']}/sync")
+    assert response.status_code == 200
+    sync.assert_called_once_with(mapping_id=mapping["id"], actor="admin")
+
+    assert client.delete(f"/admin/api/public-ip/mappings/{mapping['id']}").status_code == 200
+    assert client.get("/admin/api/public-ip").get_json()["mappings"] == []

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -596,3 +596,29 @@ def test_public_ip_mapping_api_crud_and_manual_sync(configured):
 
     assert client.delete(f"/admin/api/public-ip/mappings/{mapping['id']}").status_code == 200
     assert client.get("/admin/api/public-ip").get_json()["mappings"] == []
+
+
+def test_public_ip_mapping_mutations_are_blocked_during_sync(configured):
+    configured.dbstore.create_user("admin", "correct-horse-battery-staple")
+    client = configured.app.test_client()
+    client.post("/admin/api/login", json={
+        "username": "admin", "password": "correct-horse-battery-staple",
+    })
+    mapping = configured.dbstore.create_public_ip_mapping(
+        "home.example.net", "posture:Home",
+    )
+
+    with patch("admin.public_ip_updater.try_lock", return_value=None):
+        create = client.post("/admin/api/public-ip/mappings", json={
+            "hostname": "office.example.net", "posture_name": "Office",
+        })
+        update = client.put(f"/admin/api/public-ip/mappings/{mapping['id']}", json={
+            "hostname": "new.example.net", "posture_name": "New",
+        })
+        delete = client.delete(f"/admin/api/public-ip/mappings/{mapping['id']}")
+
+    assert create.status_code == 409
+    assert update.status_code == 409
+    assert delete.status_code == 409
+    assert "synchronization is in progress" in update.get_json()["error"]
+    assert configured.dbstore.get_public_ip_mapping(mapping["id"])["hostname"] == "home.example.net"

--- a/tests/test_dbstore.py
+++ b/tests/test_dbstore.py
@@ -523,17 +523,14 @@ def test_public_ip_sync_audit_uses_consistent_change_diffs(tmp_path):
     dbstore.init_db()
 
     dbstore.audit_public_ip_sync(
-        7, "posture:Home", "home.example.net", "1.1.1.1", "8.8.8.8",
-        "tailscale-policy.hujson", "admin",
+        7, "1.1.1.1", "8.8.8.8", "admin",
     )
 
     row = dbstore.list_audit_log(entity_type="public_ip_mapping")[0]
     assert row["changes"] == {
-        "posture_name": {"old": "posture:Home", "new": "posture:Home"},
-        "hostname": {"old": "home.example.net", "new": "home.example.net"},
         "public_ip": {"old": "1.1.1.1", "new": "8.8.8.8"},
-        "backup": {"old": None, "new": "tailscale-policy.hujson"},
     }
+    assert dbstore.list_audit_log_changed_fields("public_ip_mapping") == ["public_ip"]
 
 
 def test_audit_changes_contains_search(tmp_path):

--- a/tests/test_dbstore.py
+++ b/tests/test_dbstore.py
@@ -518,6 +518,24 @@ def test_audit_changed_field_options_exclude_setting_wrappers(tmp_path):
     assert dbstore.list_audit_log_changed_fields("device") == ["client_version", "hostname", "os"]
 
 
+def test_public_ip_sync_audit_uses_consistent_change_diffs(tmp_path):
+    dbstore.configure(str(tmp_path / "healthcheck.db"))
+    dbstore.init_db()
+
+    dbstore.audit_public_ip_sync(
+        7, "posture:Home", "home.example.net", "1.1.1.1", "8.8.8.8",
+        "tailscale-policy.hujson", "admin",
+    )
+
+    row = dbstore.list_audit_log(entity_type="public_ip_mapping")[0]
+    assert row["changes"] == {
+        "posture_name": {"old": "posture:Home", "new": "posture:Home"},
+        "hostname": {"old": "home.example.net", "new": "home.example.net"},
+        "public_ip": {"old": "1.1.1.1", "new": "8.8.8.8"},
+        "backup": {"old": None, "new": "tailscale-policy.hujson"},
+    }
+
+
 def test_audit_changes_contains_search(tmp_path):
     """Free-text search covers values, not just field names - that's the point
     of it next to the changed-field select."""

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -205,3 +205,38 @@ def test_identifier_metrics_stay_scoped_to_the_single_device(tailnet):
     assert metrics["counter_healthy_true"] == 0
     assert metrics["counter_healthy_false"] == 1
     assert metrics["counter_healthy_online_false"] == 1
+
+
+def test_public_ip_mapping_error_optionally_affects_overall_health(tmp_path):
+    m = _load_healthcheck(tmp_path / "public-ip.db")
+    m.fetch_devices = lambda: [_device("d1", "alpha")]
+    mapping = m.dbstore.create_public_ip_mapping("home.example.net", "posture:Home")
+    m.dbstore.set_public_ip_mapping_result(mapping["id"], status="error", error="DNS failed")
+    m.dbstore.set_setting("public_ip_updater_enabled", "YES")
+
+    metrics = _json(m.app.test_client(), "/health")["metrics"]
+    assert metrics["public_ip_updater_healthy"] is False
+    assert metrics["global_healthy"] is True  # backward-compatible default
+
+    m.dbstore.set_setting("public_ip_errors_affect_health", "YES")
+    metrics = _json(m.app.test_client(), "/health")["metrics"]
+    assert metrics["global_healthy"] is False
+    assert metrics["counter_public_ip_mapping_error"] == 1
+
+
+def test_public_ip_status_endpoint_reports_mappings_and_metrics(tmp_path):
+    m = _load_healthcheck(tmp_path / "public-ip-api.db")
+    mapping = m.dbstore.create_public_ip_mapping("home.example.net", "posture:Home")
+    m.dbstore.set_public_ip_mapping_result(
+        mapping["id"], status="healthy", resolved_ip="8.8.8.8",
+        configured_ip="8.8.8.8", success=True,
+    )
+    m.dbstore.set_setting("public_ip_updater_enabled", "YES")
+
+    response = m.app.test_client().get("/public-ip")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["mappings"][0]["posture_name"] == "posture:Home"
+    assert body["mappings"][0]["healthy"] is True
+    assert body["metrics"]["global_public_ip_healthy"] is True
+    assert body["metrics"]["counter_mapping_healthy"] == 1

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -17,8 +17,10 @@ def _cfg(**overrides):
 
 
 def test_get_enabled_events_parses_and_filters_unknown():
-    assert notifier.get_enabled_events("device_unhealthy, bogus_event, global_unhealthy") == {
-        "device_unhealthy", "global_unhealthy",
+    assert notifier.get_enabled_events(
+        "device_unhealthy, bogus_event, global_unhealthy, public_ip_changed"
+    ) == {
+        "device_unhealthy", "global_unhealthy", "public_ip_changed",
     }
     assert notifier.get_enabled_events("") == set()
     assert notifier.get_enabled_events(None) == set()

--- a/tests/test_poller_notifications.py
+++ b/tests/test_poller_notifications.py
@@ -18,7 +18,7 @@ CFG = {
     "apprise_bearer_token": "",
     "notification_events": ",".join([
         "device_unhealthy", "device_healthy_again", "device_needs_signing", "device_signed",
-        "key_expiring", "global_unhealthy", "global_healthy_restored",
+        "key_expiring", "global_unhealthy", "global_healthy_restored", "public_ip_changed",
     ]),
     "notify_include_tags": "",
     "notify_exclude_tags": "",
@@ -130,6 +130,39 @@ def test_global_health_transition_notifies(mock_notify, tmp_path):
     dbstore.set_health_state("global", "tailnet", True)
     poller._process_global_notifications(CFG, {"global_healthy": False, "counter_healthy_false": 2})
     assert mock_notify.call_args[0][0] == "global_unhealthy"
+
+
+@patch("poller.notifier.notify", return_value=(True, None))
+def test_global_health_notification_identifies_public_ip_errors(mock_notify, tmp_path):
+    _fresh_db(tmp_path)
+    dbstore.set_health_state("global", "tailnet", True)
+    poller._process_global_notifications(CFG, {
+        "global_healthy": False,
+        "counter_healthy_false": 0,
+        "counter_public_ip_mapping_error": 2,
+    })
+    assert "0 device(s) currently unhealthy" in mock_notify.call_args[0][2]
+    assert "2 public-IP posture mapping(s)" in mock_notify.call_args[0][2]
+
+
+@patch("poller.notifier.notify", return_value=(True, None))
+def test_public_ip_change_notification_includes_mapping_and_addresses(mock_notify, tmp_path):
+    _fresh_db(tmp_path)
+    for name, value in CFG.items():
+        if name in dbstore.SETTINGS_REGISTRY:
+            dbstore.set_setting(name, value)
+
+    poller._notify_public_ip_changes([{
+        "mapping_id": 7,
+        "posture_name": "posture:Home",
+        "hostname": "home.example.net",
+        "old_ip": "1.1.1.1",
+        "new_ip": "8.8.8.8",
+    }])
+
+    assert mock_notify.call_args[0][0] == "public_ip_changed"
+    assert mock_notify.call_args[0][1] == "Public IP changed for posture:Home"
+    assert "home.example.net changed from 1.1.1.1 to 8.8.8.8" in mock_notify.call_args[0][2]
 
 
 @patch("poller.notifier.notify", return_value=(True, None))

--- a/tests/test_public_ip_updater.py
+++ b/tests/test_public_ip_updater.py
@@ -101,6 +101,9 @@ def test_sync_updates_multiple_rules_with_one_backup_and_post(fresh_db, monkeypa
     backup = Path(fresh_db, "public-ip-policy-backups", result["backup"])
     assert backup.read_bytes() == POLICY.encode()
     assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    audit_rows = dbstore.list_audit_log(entity_type="public_ip_mapping", action="updated")
+    assert len(audit_rows) == 2
+    assert all(row["actor"] is None for row in audit_rows)
 
 
 def test_sync_aborts_entire_batch_on_one_dns_failure(fresh_db, monkeypatch):

--- a/tests/test_public_ip_updater.py
+++ b/tests/test_public_ip_updater.py
@@ -1,0 +1,121 @@
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
+
+import dbstore  # noqa: E402
+import public_ip_updater as updater  # noqa: E402
+
+
+POLICY = '''{
+  // formatting and comments must survive
+  "postures": {
+    "posture:Home": ["ip:publicAddress == '8.8.4.4'",],
+    "posture:Office": ["ip:publicAddress != '1.0.0.1'"],
+  },
+  "acls": [],
+}
+'''
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    dbstore.configure(str(tmp_path / "healthcheck.db"))
+    dbstore.init_db()
+    return tmp_path
+
+
+def test_update_rules_changes_only_mapped_ip_tokens():
+    old, changed = updater.update_rules(POLICY, {
+        "posture:Home": "9.9.9.9",
+        "posture:Office": "1.1.1.1",
+    })
+    assert old == {"posture:Home": "8.8.4.4", "posture:Office": "1.0.0.1"}
+    assert changed == POLICY.replace("8.8.4.4", "9.9.9.9").replace("1.0.0.1", "1.1.1.1")
+
+
+def test_update_rules_rejects_missing_or_multi_condition_posture():
+    with pytest.raises(updater.UpdateError, match="must exist exactly once"):
+        updater.update_rules(POLICY, {"posture:Missing": "8.8.8.8"})
+    multi = POLICY.replace(
+        '"posture:Home": ["ip:publicAddress == \'8.8.4.4\'",]',
+        '"posture:Home": ["ip:publicAddress == \'8.8.4.4\'", "node:os == \'linux\'"],',
+    )
+    with pytest.raises(updater.UpdateError, match="exactly one string rule"):
+        updater.update_rules(multi, {"posture:Home": "8.8.8.8"})
+
+
+def test_resolver_selects_first_sorted_public_ipv4(monkeypatch):
+    answers = [
+        (None, None, None, None, ("9.9.9.9", 0)),
+        (None, None, None, None, ("192.168.1.2", 0)),
+        (None, None, None, None, ("1.1.1.1", 0)),
+    ]
+    monkeypatch.setattr(updater.socket, "getaddrinfo", lambda *args: answers)
+    assert updater.resolve_public_ipv4("home.example.net") == "1.1.1.1"
+
+
+def test_mapping_crud_and_duplicate_posture(fresh_db):
+    first = dbstore.create_public_ip_mapping("home.example.net", "posture:Home", actor="alice")
+    assert first["enabled"] is True
+    assert first["status"] == "pending"
+    with pytest.raises(Exception):
+        dbstore.create_public_ip_mapping("other.example.net", "posture:Home")
+    updated = dbstore.update_public_ip_mapping(
+        first["id"], "new.example.net", "posture:New", False, actor="alice"
+    )
+    assert updated["hostname"] == "new.example.net"
+    assert updated["enabled"] is False
+    assert dbstore.delete_public_ip_mapping(first["id"], actor="alice") is True
+
+
+def test_sync_updates_multiple_rules_with_one_backup_and_post(fresh_db, monkeypatch):
+    home = dbstore.create_public_ip_mapping("home.example.net", "posture:Home")
+    office = dbstore.create_public_ip_mapping("office.example.net", "posture:Office")
+    addresses = {"home.example.net": "9.9.9.9", "office.example.net": "1.1.1.1"}
+    monkeypatch.setattr(updater, "resolve_public_ipv4", lambda host: addresses[host])
+
+    class Response:
+        content = POLICY.encode()
+        headers = {"ETag": '"policy-v1"'}
+
+    calls = []
+
+    def request(method, url, auth, timeout, body=None, content_type=None, etag=None):
+        calls.append((method, url, body, etag))
+        return Response()
+
+    monkeypatch.setattr(updater, "_api_request", request)
+    result = updater.sync([home, office], "example.ts.net", {"Authorization": "Bearer x"}, 5)
+    assert result["ok"] is True
+    assert result["changed"] == 2
+    assert [call[0] for call in calls] == ["GET", "POST", "POST"]
+    assert calls[1][1].endswith("/validate")
+    assert calls[2][3] == '"policy-v1"'
+    assert b"9.9.9.9" in calls[2][2] and b"1.1.1.1" in calls[2][2]
+    backup = Path(fresh_db, "public-ip-policy-backups", result["backup"])
+    assert backup.read_bytes() == POLICY.encode()
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+
+
+def test_sync_aborts_entire_batch_on_one_dns_failure(fresh_db, monkeypatch):
+    home = dbstore.create_public_ip_mapping("home.example.net", "posture:Home")
+    office = dbstore.create_public_ip_mapping("bad.example.net", "posture:Office")
+
+    def resolve(host):
+        if host.startswith("bad"):
+            raise updater.UpdateError("DNS failed")
+        return "8.8.8.8"
+
+    monkeypatch.setattr(updater, "resolve_public_ipv4", resolve)
+    request = Mock()
+    monkeypatch.setattr(updater, "_api_request", request)
+    result = updater.sync([home, office], "example.ts.net", {}, 5)
+    assert result["ok"] is False
+    request.assert_not_called()
+    assert all(item["status"] == "error" for item in dbstore.list_public_ip_mappings())

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -147,3 +147,39 @@ def test_unauthorized_401_refreshes_token_and_succeeds(monkeypatch):
     # Should only be a single attempt with one inline retry due to 401
     assert calls["count"] == 2
 
+
+def test_authenticated_post_refreshes_oauth_and_preserves_request(monkeypatch, tmp_path):
+    module = _load_healthcheck_with_env({
+        "MAX_RETRIES": "2",
+        "DATABASE_PATH": str(tmp_path / "healthcheck.db"),
+    })
+
+    class DummyResponse:
+        def __init__(self, code):
+            self.status_code = code
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise AssertionError(f"HTTP {self.status_code}")
+
+    calls = []
+
+    def fake_request(method, url, headers=None, data=None, timeout=None):
+        calls.append((method, url, dict(headers or {}), data, timeout))
+        return DummyResponse(401 if len(calls) == 1 else 200)
+
+    def fake_fetch_token():
+        module.ACCESS_TOKEN = "refreshed-token"
+
+    monkeypatch.setattr(module.requests, "request", fake_request)
+    monkeypatch.setattr(module, "fetch_oauth_token", fake_fetch_token)
+
+    response = module.make_authenticated_request(
+        "https://example.invalid/acl", {"Authorization": "Bearer old"},
+        method="POST", data=b"policy", timeout=7,
+    )
+
+    assert response.status_code == 200
+    assert [call[0] for call in calls] == ["POST", "POST"]
+    assert calls[1][2]["Authorization"] == "Bearer refreshed-token"
+    assert calls[1][3:] == (b"policy", 7)

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -133,6 +133,7 @@ def test_metrics_history_record_and_purge(tmp_path):
         "counter_healthy_online_true": 6, "counter_healthy_online_false": 0,
         "counter_key_healthy_true": 5, "counter_key_healthy_false": 1,
         "counter_update_healthy_true": 4, "counter_update_healthy_false": 2,
+        "counter_public_ip_mapping_healthy": 2, "counter_public_ip_mapping_error": 1,
     }
     keys_metrics = {"counter_key_healthy_true": 3, "counter_key_healthy_false": 0}
 
@@ -141,6 +142,8 @@ def test_metrics_history_record_and_purge(tmp_path):
     assert len(history) == 1
     assert history[0]["counter_healthy_true"] == 5
     assert history[0]["keys_counter_healthy_true"] == 3
+    assert history[0]["public_ip_mapping_healthy"] == 2
+    assert history[0]["public_ip_mapping_error"] == 1
 
     with dbstore.get_connection() as conn:
         conn.execute("UPDATE metrics_history SET occurred_at = '2000-01-01T00:00:00+00:00'")


### PR DESCRIPTION
## What changed

- Add multi-mapping DynDNS to Tailscale public-IP posture synchronization.
- Preserve HuJSON formatting, validate policy updates, use ETag concurrency protection, and retain local backups.
- Add updater settings, audit and operational logging, health integration, and historical metrics.
- Add a sidebar status table, Overview health graph, monitoring API, and interactive API documentation.
- Accept posture rule names without requiring users to enter the `posture:` prefix.

## Why

Dynamic public addresses can now be kept synchronized with Tailscale `ip:publicAddress` posture rules directly from the application, with monitoring and safe update controls.

## Validation

- `pytest -q`: 200 passed
- Python `flake8`: passed
- Frontend lint/type-check/build: passed (existing warnings only)
- Updated container image verified healthy

## Summary by Sourcery

Add DynDNS-based public IP posture synchronization with health integration, manual and scheduled updates, and UI support.

New Features:
- Introduce DynDNS hostname to ip:publicAddress posture rule mappings managed via a new Public IP admin page and API.
- Add background synchronization of configured mappings into Tailscale policy with HuJSON-preserving updates, ETag concurrency control, and local policy backups.
- Expose a monitoring-friendly /public-ip endpoint and integrate public IP updater metrics into overall health status and trends.

Enhancements:
- Extend health computation and metrics history to account for public IP updater status and optionally include synchronization errors in overall health.
- Add new configuration settings for enabling the public IP updater, controlling backup retention, and determining whether updater errors affect health.
- Augment the admin sidebar, overview dashboard, and API docs to surface public IP posture sync status, controls, and documentation.

Build:
- Include the new public_ip_updater module in the flake8 linting workflow to keep it covered by CI.

Documentation:
- Update the README to describe DynDNS public IP posture automation and document new environment variables for configuring the updater.

Tests:
- Add unit and integration tests for the public IP updater, admin CRUD and sync APIs, health integration behavior, and metrics history recording.